### PR TITLE
Fix snip20 commands after Stargate upgrade

### DIFF
--- a/cmd/secretd/secret20.go
+++ b/cmd/secretd/secret20.go
@@ -379,7 +379,7 @@ func s20DepositCmd() *cobra.Command {
 
 	flags.AddTxFlagsToCmd(cmd)
 	cmd.Flags().String(flagAmount, "", "The amount of currency to deposit in the contract, e.g. 1000000uscrt")
-	cmd.MarkFlagRequired(flagAmount)
+	_ = cmd.MarkFlagRequired(flagAmount)
 
 	return cmd
 }

--- a/cmd/secretd/secret20.go
+++ b/cmd/secretd/secret20.go
@@ -9,18 +9,21 @@ import (
 	"github.com/enigmampc/SecretNetwork/x/compute"
 	"github.com/enigmampc/SecretNetwork/x/compute/client/cli"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"math/rand"
 	"strconv"
+	"strings"
 	"time"
 )
 
+const MessageBlockSize = 256
 const flagAmount = "amount"
 
-// GetQueryCmd returns the cli query commands for this module
+// S20GetQueryCmd GetQueryCmd returns the cli query commands for this module
 func S20GetQueryCmd() *cobra.Command {
 	s20QueryCmd := &cobra.Command{
-		Use:                        "secret20",
-		Short:                      "*EXPERIMENTAL* Querying commands for the secret20 contracts",
+		Use:                        "snip20",
+		Short:                      "Querying commands for the secret20 contracts",
 		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,
@@ -28,45 +31,42 @@ func S20GetQueryCmd() *cobra.Command {
 
 	s20QueryCmd.AddCommand(
 		S20BalanceCmd(),
-		S20TransferHistoryCmd(),
-	)
+		S20TransferHistoryCmd())
 
 	return s20QueryCmd
 }
 
-// GetTxCmd returns the transaction commands for this module
+// S20GetTxCmd GetTxCmd returns the transaction commands for this module
 func S20GetTxCmd() *cobra.Command {
 	s20TxCmd := &cobra.Command{
-		Use:                        "secret20",
-		Short:                      "*EXPERIMENTAL* Secret20 transactions subcommands",
+		Use:                        "snip20",
+		Short:                      "Snip20 transactions subcommands",
 		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,
 		RunE:                       client.ValidateCmd,
 	}
 
 	s20TxCmd.AddCommand(
+		s20TransferCmd(),
 		s20SendCmd(),
 		s20CreatingViewingKey(),
 		s20DepositCmd(),
-		s20Withdraw(),
+		s20Redeem(),
 		s20SetViewingKey(),
-	)
+		s20BurnCmd())
 
 	return s20TxCmd
 }
 
 func S20TransferHistoryCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "history [contract address] [account] [viewing_key]",
-		Short: "*EXPERIMENTAL* View your transaction history",
-		Long:  `Print out all transactions you have been a part of - either as a sender or recipient`,
-		Args:  cobra.ExactArgs(3),
+		Use:   "history [contract address] [account] [viewing_key] [optional: page, default: 0] [optional: page_size, default: 10]",
+		Short: "View your transaction history",
+		Long:  `Print out transactions you have been a part of - either as a sender or recipient`,
+		Args:  cobra.MinimumNArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			cliCtx, err := client.GetClientQueryContext(cmd)
-			if err != nil {
-				return err
-			}
 
 			contractAddr, err := addressFromBechOrLabel(args[0], cliCtx)
 			if err != nil {
@@ -83,7 +83,24 @@ func S20TransferHistoryCmd() *cobra.Command {
 				return errors.New("viewing key must not be empty")
 			}
 
-			queryData := transferHistoryMsg(addr, key)
+			var page uint64 = 0
+			var pageSize uint64 = 10
+
+			if len(args) == 4 {
+				page, err = strconv.ParseUint(args[3], 10, 32)
+				if err != nil {
+					return err
+				}
+			}
+
+			if len(args) == 5 {
+				pageSize, err = strconv.ParseUint(args[3], 10, 32)
+				if err != nil {
+					return err
+				}
+			}
+
+			queryData := queryTransferHistoryMsg(addr, key, uint32(page), uint32(pageSize))
 
 			err = cli.QueryWithData(contractAddr, queryData, cliCtx)
 			if err != nil {
@@ -100,18 +117,15 @@ func S20TransferHistoryCmd() *cobra.Command {
 func S20BalanceCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "balance [contract address] [account] [viewing_key]",
-		Short: "*EXPERIMENTAL* See your current balance for a token",
+		Short: "See your current balance for a token",
 		Long: `See your current balance for a token. Viewing key must be set for this command to work. If you did not set your viewing 
 key yet, use the "create-viewing-key" command. Otherwise, you can still see your current balance using a raw transaction`,
 		Args: cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
-			clientCtx, err := client.GetClientQueryContext(cmd)
-			if err != nil {
-				return err
-			}
+			cliCtx, err := client.GetClientQueryContext(cmd)
 
-			contractAddr, err := addressFromBechOrLabel(args[0], clientCtx)
+			contractAddr, err := addressFromBechOrLabel(args[0], cliCtx)
 			if err != nil {
 				return err
 			}
@@ -126,9 +140,9 @@ key yet, use the "create-viewing-key" command. Otherwise, you can still see your
 				return errors.New("viewing key must not be empty")
 			}
 
-			queryData := balanceMsg(addr, key)
+			queryData := queryBalanceMsg(addr, key)
 
-			err = cli.QueryWithData(contractAddr, queryData, clientCtx)
+			err = cli.QueryWithData(contractAddr, queryData, cliCtx)
 			if err != nil {
 				return err
 			}
@@ -141,7 +155,6 @@ key yet, use the "create-viewing-key" command. Otherwise, you can still see your
 }
 
 func addressFromBechOrLabel(addressOrLabel string, cliCtx client.Context) (string, error) {
-
 	var contractAddr string
 
 	_, err := sdk.AccAddressFromBech32(addressOrLabel)
@@ -159,21 +172,18 @@ func addressFromBechOrLabel(addressOrLabel string, cliCtx client.Context) (strin
 	return contractAddr, nil
 }
 
-func s20SendCmd() *cobra.Command {
-
+func s20TransferCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "send [contract address or label] [to account] [amount]",
-		Short: "*EXPERIMENTAL* send tokens to another address",
-		Long:  `send tokens to another address`,
-		Args:  cobra.MinimumNArgs(3),
+		Use:   "transfer [contract address or label] [to account] [amount]",
+		Short: "Transfer tokens to another address",
+		Long:  `transfer tokens to another address`,
+		Args:  cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
-			clientCtx, err := client.GetClientTxContext(cmd)
-			if err != nil {
-				return err
-			}
+			////inBuf := bufio.NewReader(cmd.InOrStdin())
+			cliCtx, err := client.GetClientTxContext(cmd)
 
-			contractAddrStr, err := addressFromBechOrLabel(args[0], clientCtx)
+			contractAddrStr, err := addressFromBechOrLabel(args[0], cliCtx)
 			if err != nil {
 				return err
 			}
@@ -190,13 +200,13 @@ func s20SendCmd() *cobra.Command {
 
 			amount := args[2]
 			_, err = strconv.ParseUint(amount, 10, 64)
-			if err == nil {
+			if err != nil {
 				return errors.New("invalid amount format")
 			}
 
-			msg := sendCoinMsg(toAddr, amount)
+			msg := handleTransferMsg(toAddr, amount)
 
-			return cli.ExecuteWithData(cmd, contractAddr, msg, "", false, "", "", clientCtx)
+			return cli.ExecuteWithData(cmd, contractAddr, msg, "", false, "", "", cliCtx)
 		},
 	}
 
@@ -204,21 +214,16 @@ func s20SendCmd() *cobra.Command {
 }
 
 func s20CreatingViewingKey() *cobra.Command {
-
 	cmd := &cobra.Command{
 		Use:   "create-viewing-key [contract address or label]",
 		Short: "*EXPERIMENTAL* Create a new viewing key. To view the resulting key, use 'secretcli q compute tx <TX_HASH>'",
 		Long: `This allows a user to generate a key that enables off-chain queries. 
-This way you can perform balance and transaction history queries without waiting for a transaction on-chain. 
-This transaction will be expensive, so you must have about 3,000,000 gas in your account to perform this step.
- This is intended to make queries take a long time to execute to be resistant to brute-force attacks.`,
-		Args: cobra.MinimumNArgs(1),
+This way you can perform balance and transaction history queries without waiting for a transaction on-chain.`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
+			//inBuf := bufio.NewReader(cmd.InOrStdin())
 			cliCtx, err := client.GetClientTxContext(cmd)
-			if err != nil {
-				return err
-			}
 
 			contractAddrStr, err := addressFromBechOrLabel(args[0], cliCtx)
 			if err != nil {
@@ -239,7 +244,7 @@ This transaction will be expensive, so you must have about 3,000,000 gas in your
 
 			randomData := hex.EncodeToString(byteArr)[:64]
 
-			msg := createViewingKeyMsg(randomData)
+			msg := handleCreateViewingKeyMsg(randomData)
 
 			return cli.ExecuteWithData(cmd, contractAddr, msg, "", false, "", "", cliCtx)
 		},
@@ -249,20 +254,17 @@ This transaction will be expensive, so you must have about 3,000,000 gas in your
 }
 
 func s20SetViewingKey() *cobra.Command {
-
 	cmd := &cobra.Command{
 		Use:   "set-viewing-key [contract address or label] [viewing-key]",
-		Short: "*EXPERIMENTAL* sets the viewing key for your account",
+		Short: "*EXPERIMENTAL* Sets the viewing key for your account",
 		Long: `This command is useful if you want to manage multiple secret tokens with the same viewing key. *WARNING*:
 This should only be used to duplicate keys created with the create-viewing-key command, or if you really really know what
 you're doing`,
-		Args: cobra.MinimumNArgs(1),
+		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
+			//inBuf := bufio.NewReader(cmd.InOrStdin())
 			cliCtx, err := client.GetClientTxContext(cmd)
-			if err != nil {
-				return err
-			}
 
 			contractAddrStr, err := addressFromBechOrLabel(args[0], cliCtx)
 			if err != nil {
@@ -274,7 +276,7 @@ you're doing`,
 				return errors.New("invalid contract address or label")
 			}
 
-			msg := setViewingKeyMsg(args[1])
+			msg := handleSetViewingKeyMsg(args[1])
 
 			return cli.ExecuteWithData(cmd, contractAddr, msg, "", false, "", "", cliCtx)
 		},
@@ -284,18 +286,15 @@ you're doing`,
 }
 
 func s20DepositCmd() *cobra.Command {
-
 	cmd := &cobra.Command{
 		Use:   "deposit [contract address or label]",
-		Short: "Convert your SCRT into a secret token",
+		Short: "*EXPERIMENTAL* convert your SCRT into a secret token",
 		Long:  `Convert your SCRT into a secret token. This command will only work if the token supports native currency conversion`,
-		Args:  cobra.MinimumNArgs(1),
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
+			//inBuf := bufio.NewReader(cmd.InOrStdin())
 			cliCtx, err := client.GetClientTxContext(cmd)
-			if err != nil {
-				return err
-			}
 
 			contractAddrStr, err := addressFromBechOrLabel(args[0], cliCtx)
 			if err != nil {
@@ -304,18 +303,12 @@ func s20DepositCmd() *cobra.Command {
 
 			contractAddr, err := sdk.AccAddressFromBech32(contractAddrStr)
 			if err != nil {
-				return fmt.Errorf("invalid contract address or label: %s", err)
+				return errors.New("invalid contract address or label")
 			}
 
-			msg := depositMsg()
+			msg := handleDepositMsg()
 
-			amountStr, err := cmd.Flags().GetString(flagAmount)
-			if err != nil {
-				return fmt.Errorf("invalid amount: %s", err)
-			}
-			if amountStr == "" {
-				return fmt.Errorf("amount must not be empty")
-			}
+			amountStr := viper.GetString(flagAmount)
 
 			return cli.ExecuteWithData(cmd, contractAddr, msg, amountStr, false, "", "", cliCtx)
 		},
@@ -324,19 +317,17 @@ func s20DepositCmd() *cobra.Command {
 	return cmd
 }
 
-func s20Withdraw() *cobra.Command {
+func s20Redeem() *cobra.Command {
 
 	cmd := &cobra.Command{
-		Use:   "withdraw [contract address or label] [amount]",
-		Short: "Convert your secret token back to SCRT",
+		Use:   "redeem [contract address or label] [amount]",
+		Short: "*EXPERIMENTAL* convert your secret token back to SCRT",
 		Long:  `Convert your secret token back to SCRT. This command will only work if the token supports native currency conversion`,
-		Args:  cobra.MinimumNArgs(2),
+		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
+			//inBuf := bufio.NewReader(cmd.InOrStdin())
 			cliCtx, err := client.GetClientTxContext(cmd)
-			if err != nil {
-				return err
-			}
 
 			contractAddrStr, err := addressFromBechOrLabel(args[0], cliCtx)
 			if err != nil {
@@ -350,7 +341,7 @@ func s20Withdraw() *cobra.Command {
 
 			amount := args[1]
 
-			msg := withdrawMsg(amount)
+			msg := handleRedeemMsg(amount)
 
 			return cli.ExecuteWithData(cmd, contractAddr, msg, "", false, "", "", cliCtx)
 		},
@@ -359,30 +350,146 @@ func s20Withdraw() *cobra.Command {
 	return cmd
 }
 
-func transferHistoryMsg(fromAddress sdk.AccAddress, viewingKey string) []byte {
-	return []byte(fmt.Sprintf("{\"transfers\": {\"address\": \"%s\", \"key\": \"%s\"}}", fromAddress.String(), viewingKey))
+func s20SendCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "send [contract_address or label] [to_account] [amount] [optional: callback_message]",
+		Short: "*EXPERIMENTAL* send tokens to another address. Optionally add a callback message",
+		Long: `Send tokens to another address (contract or not). If 'to_account' is a contract, you can optionally add a callback message to this contract.
+If no callback provided, this is identical to 'transfer'.`,
+		Args: cobra.MinimumNArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			//inBuf := bufio.NewReader(cmd.InOrStdin())
+			cliCtx, err := client.GetClientTxContext(cmd)
+
+			contractAddrStr, err := addressFromBechOrLabel(args[0], cliCtx)
+			if err != nil {
+				return err
+			}
+
+			contractAddr, err := sdk.AccAddressFromBech32(contractAddrStr)
+			if err != nil {
+				return errors.New("invalid contract address or label")
+			}
+
+			toAddr, err := sdk.AccAddressFromBech32(args[1])
+			if err != nil {
+				return errors.New("invalid recipient address")
+			}
+
+			amount := args[2]
+			_, err = strconv.ParseUint(amount, 10, 64)
+			if err != nil {
+				return errors.New("invalid amount format")
+			}
+
+			var msg []byte
+			if len(args) > 3 {
+				callback := args[3]
+				msg = handleSendWithCallbackMsg(toAddr, amount, callback)
+			} else {
+				msg = handleSendMsg(toAddr, amount)
+			}
+
+			return cli.ExecuteWithData(cmd, contractAddr, msg, "", false, "", "", cliCtx)
+		},
+	}
+
+	return cmd
 }
 
-func balanceMsg(fromAddress sdk.AccAddress, viewingKey string) []byte {
-	return []byte(fmt.Sprintf("{\"balance\": {\"address\": \"%s\", \"key\": \"%s\"}}", fromAddress.String(), viewingKey))
+func s20BurnCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "burn [contract_address or label] [amount]",
+		Short: "*EXPERIMENTAL* burn tokens forever",
+		Long: `Burn tokens. The tokens will be removed from your account and will be lost forever.
+WARNING! This action is irreversible and permanent! use at your own risk`,
+		Args: cobra.MinimumNArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			//inBuf := bufio.NewReader(cmd.InOrStdin())
+			cliCtx, err := client.GetClientTxContext(cmd)
+
+			contractAddrStr, err := addressFromBechOrLabel(args[0], cliCtx)
+			if err != nil {
+				return err
+			}
+
+			contractAddr, err := sdk.AccAddressFromBech32(contractAddrStr)
+			if err != nil {
+				return errors.New("invalid contract address or label")
+			}
+
+			amount := args[1]
+			_, err = strconv.ParseUint(amount, 10, 64)
+			if err != nil {
+				return errors.New("invalid amount format")
+			}
+
+			msg := handleBurnMsg(contractAddr, amount)
+
+			return cli.ExecuteWithData(cmd, contractAddr, msg, "", false, "", "", cliCtx)
+		},
+	}
+
+	return cmd
 }
 
-func sendCoinMsg(toAddress sdk.AccAddress, amount string) []byte {
-	return []byte(fmt.Sprintf("{\"transfer\": {\"recipient\": \"%s\", \"amount\": \"%s\"}}", toAddress.String(), amount))
+func spacePad(blockSize int, message string) string {
+	surplus := len(message) % blockSize
+	if surplus == 0 {
+		return message
+	}
+
+	missing := blockSize - surplus
+	return message + strings.Repeat(" ", missing)
 }
 
-func depositMsg() []byte {
-	return []byte(fmt.Sprintf("{\"deposit\": {}}"))
+func queryTransferHistoryMsg(fromAddress sdk.AccAddress, viewingKey string, page uint32, pageSize uint32) []byte {
+	return []byte(spacePad(MessageBlockSize,
+		fmt.Sprintf("{\"transfer_history\": {\"address\": \"%s\", \"key\": \"%s\", \"page\": %d, \"page_size\": %d}}",
+			fromAddress.String(),
+			viewingKey,
+			page,
+			pageSize)))
 }
 
-func withdrawMsg(amount string) []byte {
-	return []byte(fmt.Sprintf("{\"withdraw\": {\"amount\": \"%s\"}}", amount))
+func queryBalanceMsg(fromAddress sdk.AccAddress, viewingKey string) []byte {
+	return []byte(spacePad(MessageBlockSize, fmt.Sprintf("{\"balance\": {\"address\": \"%s\", \"key\": \"%s\"}}", fromAddress.String(), viewingKey)))
 }
 
-func createViewingKeyMsg(data string) []byte {
-	return []byte(fmt.Sprintf("{\"create_viewing_key\": {\"entropy\": \"%s\"}}", data))
+func handleTransferMsg(toAddress sdk.AccAddress, amount string) []byte {
+	return []byte(spacePad(MessageBlockSize, fmt.Sprintf("{\"transfer\": {\"recipient\": \"%s\", \"amount\": \"%s\"}}", toAddress.String(), amount)))
 }
 
-func setViewingKeyMsg(data string) []byte {
-	return []byte(fmt.Sprintf("{\"set_viewing_key\": {\"key\": \"%s\"}}", data))
+func handleDepositMsg() []byte {
+	return []byte(spacePad(MessageBlockSize, fmt.Sprintf("{\"deposit\": {}}")))
+}
+
+func handleRedeemMsg(amount string) []byte {
+	return []byte(spacePad(MessageBlockSize, fmt.Sprintf("{\"redeem\": {\"amount\": \"%s\"}}", amount)))
+}
+
+func handleCreateViewingKeyMsg(data string) []byte {
+	return []byte(spacePad(MessageBlockSize, fmt.Sprintf("{\"create_viewing_key\": {\"entropy\": \"%s\"}}", data)))
+}
+
+func handleSetViewingKeyMsg(data string) []byte {
+	return []byte(spacePad(MessageBlockSize, fmt.Sprintf("{\"set_viewing_key\": {\"key\": \"%s\"}}", data)))
+}
+
+func handleSendWithCallbackMsg(toAddress sdk.AccAddress, amount string, message string) []byte {
+	return []byte(spacePad(MessageBlockSize,
+		fmt.Sprintf("{\"send\": {\"recipient\": \"%s\", \"amount\": \"%s\", \"msg\": \"%s\"}}",
+			toAddress.String(),
+			amount,
+			message)))
+}
+
+func handleSendMsg(toAddress sdk.AccAddress, amount string) []byte {
+	return []byte(spacePad(MessageBlockSize, fmt.Sprintf("{\"send\": {\"recipient\": \"%s\", \"amount\": \"%s\"}}", toAddress.String(), amount)))
+}
+
+func handleBurnMsg(toAddress sdk.AccAddress, amount string) []byte {
+	return []byte(spacePad(MessageBlockSize, fmt.Sprintf("{\"burn\": {\"amount\": \"%s\"}}", amount)))
 }


### PR DESCRIPTION
This PR fixes all the `secretcli query snip20` and `secretcli tx snip20` commands, and does the following:
- Renamed `secretcli query snip20 history` to `secretcli query snip20 transfers`.
- Added `secretcli query snip20 txs` which uses the [SNIP-21](https://github.com/SecretFoundation/SNIPs/blob/master/SNIP-21.md) transaction history query.
- create-viewing-key now uses cryptographically secure randomness from the `crypto/rand` go module
- Renamed `secretcli tx snip20 withdraw` to `secretcli tx snip20 redeem`.