### PR TITLE
WIP: Put enclave access behind a reentrant mutex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,30 @@
 # CHANGELOG
 
-# 1.2.0-beta1
+# 1.2.2
 
-Version 1.2.0-beta1 has been released - Supernova upgrade testnet v1!
+## Secretd
+
+* Fixed issue where queries would try to access the Enclave in parallel from multiple threads,
+  causing `SGX_ERROR_OUT_OF_TCS` to be returned to users when a node was under sufficient load.
+  Queries now access the enclave one-at-a-time again.
+
+# 1.2.1
+
+This is a minor non-breaking version release. 
+
+## SecretCLI
+
+- Migrate the `secretcli tx sign-doc` command from v1. See [this](https://github.com/enigmampc/snip20-reference-impl/pull/22) for more info.
+
+# 1.2.0
+
+Version 1.2.0 has been released - the Supernova upgrade!
 
 ## Highlights
 
-* Upgraded to Cosmos SDK 0.43. Full changelog can be found [here](https://github.com/cosmos/cosmos-sdk/blob/v0.43.0/CHANGELOG.md)
+* Upgraded to Cosmos SDK 0.44.3. Full changelog can be found [here](https://github.com/cosmos/cosmos-sdk/blob/v0.44.3/CHANGELOG.md)
 
-* Gas prices are lower - as a result of performance upgrades and optimizations, gas amounts required will be much lower. We will be monitoring these metrics during the testnet period, so the numbers may not be final
+* Gas prices are lower - as a result of performance upgrades and optimizations, gas amounts required will be much lower.
 * GRPC for cosmos-sdk modules in addition to legacy REST API. See API [here](http://bootstrap.supernova.enigma.co/swagger/)
 
 * New modules:
@@ -44,7 +60,7 @@ modifying /home/\<account\>/.secretd/config/app.toml and looking for the `api` c
 
 ## SecretJS
 
-Version 0.17.0-beta1 has been released!
+Version 0.17.3 has been released!
 SecretJS has been upgraded to support the Supernova upgrade.
 All APIs remain unchanged, although the versions are NOT backwards compatible.
 
@@ -57,7 +73,7 @@ Secret-CosmWasm remains in a version that is compatabile with the v0.10 of vanil
 
 A new feature has been added - plaintext logs. To send an unencrypted log (contract output), use `plaintext_log` instead of `log`.
 This allows contracts to emit public events, and attach websockets to listen to specific events. To take advantage of this feature, compile contracts with
-`cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.2.0-beta1" }`
+`cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.2.0" }`
 
 ## Known Issues
 

--- a/cosmwasm/Cargo.lock
+++ b/cosmwasm/Cargo.lock
@@ -42,7 +42,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46254cf2fdcdf1badb5934448c1bcbe046a56537b3987d96c51a7afc5d03f293"
 dependencies = [
  "addr2line",
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "miniz_oxide",
  "object",
@@ -106,6 +106,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "clap"
 version = "2.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +155,7 @@ dependencies = [
  "log",
  "memmap",
  "parity-wasm",
+ "parking_lot",
  "schemars",
  "serde",
  "serde_json",
@@ -238,7 +245,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "wasi",
 ]
@@ -271,6 +278,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,12 +305,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2f02823cf78b754822df5f7f268fb59822e7296276d3e069d8e8cb26a14bd10"
 
 [[package]]
+name = "lock_api"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -333,6 +358,31 @@ name = "parity-wasm"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
+
+[[package]]
+name = "parking_lot"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
+dependencies = [
+ "cfg-if 1.0.0",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.10",
+ "smallvec",
+ "winapi",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -406,6 +456,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,6 +507,12 @@ dependencies = [
  "serde_derive_internals",
  "syn",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
@@ -521,11 +586,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2933378ddfeda7ea26f48c555bdad8bb446bf8a3d17832dc83e380d444cfb8c1"
 dependencies = [
  "block-buffer",
- "cfg-if",
+ "cfg-if 0.1.10",
  "cpuid-bool",
  "digest",
  "opaque-debug",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "snafu"
@@ -572,10 +643,10 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "rand",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "remove_dir_all",
  "winapi",
 ]

--- a/cosmwasm/packages/sgx-vm/Cargo.toml
+++ b/cosmwasm/packages/sgx-vm/Cargo.toml
@@ -64,6 +64,7 @@ sgx_types = { git = "https://github.com/apache/teaclave-sgx-sdk.git", rev = "a37
 sgx_urts = { git = "https://github.com/apache/teaclave-sgx-sdk.git", rev = "a37ffb9449ba6d5b6e4a9d586bbab864ae732269" }
 log = "0.4.8"
 base64 = "0.12.0"
+parking_lot = "0.11"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/cosmwasm/packages/sgx-vm/src/attestation.rs
+++ b/cosmwasm/packages/sgx-vm/src/attestation.rs
@@ -127,7 +127,7 @@ pub extern "C" fn ocall_get_update_info(
 }
 
 pub fn create_attestation_report_u(spid: &[u8], api_key: &[u8]) -> SgxResult<()> {
-    let enclave = get_enclave()?;
+    let enclave = get_enclave()?.ok_or(sgx_status_t::SGX_ERROR_OUT_OF_TCS)?;
 
     let eid = enclave.geteid();
     let mut retval = sgx_status_t::SGX_SUCCESS;
@@ -156,7 +156,7 @@ pub fn create_attestation_report_u(spid: &[u8], api_key: &[u8]) -> SgxResult<()>
 pub fn untrusted_get_encrypted_seed(
     cert: &[u8],
 ) -> SgxResult<Result<[u8; ENCRYPTED_SEED_SIZE], NodeAuthResult>> {
-    let enclave = get_enclave()?;
+    let enclave = get_enclave()?.ok_or(sgx_status_t::SGX_ERROR_OUT_OF_TCS)?;
     let eid = enclave.geteid();
     let mut retval = NodeAuthResult::Success;
     let mut seed = [0u8; ENCRYPTED_SEED_SIZE];

--- a/cosmwasm/packages/sgx-vm/src/enclave.rs
+++ b/cosmwasm/packages/sgx-vm/src/enclave.rs
@@ -108,13 +108,17 @@ lazy_static! {
     static ref SGX_ENCLAVE_CONFIGURED: Mutex<bool> = Mutex::new(false);
 }
 
+/// This const determines how many seconds we wait when trying to get access to the enclave
+/// before giving up.
+const ENCLAVE_LOCK_TIMEOUT: u64 = 6;
+
 /// Use this method when trying to get access to the enclave.
 /// You can unwrap the result when you are certain that the enclave
 /// must have been initialized if you even reached that point in the code.
 /// If `Ok(None)` is returned, that means that the enclave is currently busy.
 pub fn get_enclave() -> SgxResult<Option<EnclaveGuard>> {
     let mutex = SGX_ENCLAVE_MUTEX.as_ref().map_err(|status| *status)?;
-    let maybe_guard = mutex.get_enclave(Duration::from_secs(6));
+    let maybe_guard = mutex.get_enclave(Duration::from_secs(ENCLAVE_LOCK_TIMEOUT));
     Ok(maybe_guard)
 }
 

--- a/cosmwasm/packages/sgx-vm/src/enclave.rs
+++ b/cosmwasm/packages/sgx-vm/src/enclave.rs
@@ -111,6 +111,7 @@ lazy_static! {
 /// Use this method when trying to get access to the enclave.
 /// You can unwrap the result when you are certain that the enclave
 /// must have been initialized if you even reached that point in the code.
+/// If `Ok(None)` is returned, that means that the enclave is currently busy.
 pub fn get_enclave() -> SgxResult<Option<EnclaveGuard>> {
     let mutex = SGX_ENCLAVE_MUTEX.as_ref().map_err(|status| *status)?;
     let maybe_guard = mutex.get_enclave(Duration::from_secs(6));
@@ -173,7 +174,7 @@ pub(super) fn allocate_enclave_buffer(buffer: &[u8]) -> SgxResult<EnclaveBuffer>
     let len = buffer.len();
     let mut enclave_buffer = EnclaveBuffer::default();
 
-    let enclave_id = crate::enclave::get_enclave()
+    let enclave_id = get_enclave()
         .expect("If we got here, surely the enclave has been loaded")
         .expect("If we got here, surely we are the thread that holds the enclave")
         .geteid();

--- a/cosmwasm/packages/sgx-vm/src/enclave.rs
+++ b/cosmwasm/packages/sgx-vm/src/enclave.rs
@@ -113,7 +113,7 @@ lazy_static! {
 /// must have been initialized if you even reached that point in the code.
 pub fn get_enclave() -> SgxResult<Option<EnclaveGuard>> {
     let mutex = SGX_ENCLAVE_MUTEX.as_ref().map_err(|status| *status)?;
-    let maybe_guard = mutex.get_enclave(Duration::from_secs(2));
+    let maybe_guard = mutex.get_enclave(Duration::from_secs(6));
     Ok(maybe_guard)
 }
 

--- a/cosmwasm/packages/sgx-vm/src/enclave_tests.rs
+++ b/cosmwasm/packages/sgx-vm/src/enclave_tests.rs
@@ -8,7 +8,7 @@ extern "C" {
 }
 
 pub fn run_tests() -> SgxResult<u32> {
-    let enclave = get_enclave()?;
+    let enclave = get_enclave()?.ok_or(sgx_status_t::SGX_ERROR_OUT_OF_TCS)?;
     let mut failed_tests = 0;
     let status = unsafe { ecall_run_tests(enclave.geteid(), &mut failed_tests) };
     match status {

--- a/cosmwasm/packages/sgx-vm/src/errors/enclave.rs
+++ b/cosmwasm/packages/sgx-vm/src/errors/enclave.rs
@@ -15,6 +15,8 @@ pub enum EnclaveError {
         status: sgx_types::sgx_status_t,
         backtrace: Backtrace,
     },
+    #[snafu(display("Too many queries, please try again"))]
+    EnclaveBusy {},
 }
 
 impl EnclaveError {

--- a/cosmwasm/packages/sgx-vm/src/instance.rs
+++ b/cosmwasm/packages/sgx-vm/src/instance.rs
@@ -87,7 +87,9 @@ where
         let module = compile(code)?;
         Instance::from_module(&module, deps, gas_limit)
         */
-        let enclave = get_enclave().map_err(EnclaveError::sdk_err)?;
+        let enclave = get_enclave()
+            .map_err(EnclaveError::sdk_err)?
+            .ok_or(EnclaveError::EnclaveBusy {})?;
         let module = Module::<S, Q>::new(
             code.to_vec(),
             gas_limit,

--- a/cosmwasm/packages/sgx-vm/src/seed.rs
+++ b/cosmwasm/packages/sgx-vm/src/seed.rs
@@ -40,7 +40,7 @@ extern "C" {
 
 pub fn untrusted_health_check() -> SgxResult<HealthCheckResult> {
     //info!("Initializing enclave..");
-    let enclave = get_enclave()?;
+    let enclave = get_enclave()?.ok_or(sgx_status_t::SGX_ERROR_OUT_OF_TCS)?;
     //debug!("Initialized enclave successfully!");
 
     let eid = enclave.geteid();
@@ -57,7 +57,7 @@ pub fn untrusted_health_check() -> SgxResult<HealthCheckResult> {
 
 pub fn untrusted_init_node(master_cert: &[u8], encrypted_seed: &[u8]) -> SgxResult<()> {
     info!("Initializing enclave..");
-    let enclave = get_enclave()?;
+    let enclave = get_enclave()?.ok_or(sgx_status_t::SGX_ERROR_OUT_OF_TCS)?;
     info!("Initialized enclave successfully!");
 
     let eid = enclave.geteid();
@@ -87,7 +87,7 @@ pub fn untrusted_init_node(master_cert: &[u8], encrypted_seed: &[u8]) -> SgxResu
 
 pub fn untrusted_key_gen() -> SgxResult<[u8; 32]> {
     info!("Initializing enclave..");
-    let enclave = get_enclave()?;
+    let enclave = get_enclave()?.ok_or(sgx_status_t::SGX_ERROR_OUT_OF_TCS)?;
     info!("Initialized enclave successfully!");
 
     let eid = enclave.geteid();
@@ -109,7 +109,7 @@ pub fn untrusted_key_gen() -> SgxResult<[u8; 32]> {
 
 pub fn untrusted_init_bootstrap(spid: &[u8], api_key: &[u8]) -> SgxResult<[u8; 32]> {
     info!("Hello from just before initializing - untrusted_init_bootstrap");
-    let enclave = get_enclave()?;
+    let enclave = get_enclave()?.ok_or(sgx_status_t::SGX_ERROR_OUT_OF_TCS)?;
     info!("Hello from just after initializing - untrusted_init_bootstrap");
 
     let eid = enclave.geteid();

--- a/cosmwasm/packages/sgx-vm/src/wasmi/mod.rs
+++ b/cosmwasm/packages/sgx-vm/src/wasmi/mod.rs
@@ -1,5 +1,5 @@
 mod exports;
-mod imports;
+pub(crate) mod imports;
 mod results;
 mod utils;
 mod wrapper;

--- a/go-cosmwasm/Cargo.lock
+++ b/go-cosmwasm/Cargo.lock
@@ -48,7 +48,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46254cf2fdcdf1badb5934448c1bcbe046a56537b3987d96c51a7afc5d03f293"
 dependencies = [
  "addr2line",
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "miniz_oxide",
  "object",
@@ -124,6 +124,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "chrono"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,6 +178,7 @@ dependencies = [
  "log",
  "memmap",
  "parity-wasm",
+ "parking_lot",
  "schemars",
  "serde",
  "serde_json",
@@ -286,7 +293,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "wasi",
 ]
@@ -340,6 +347,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,12 +374,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2f02823cf78b754822df5f7f268fb59822e7296276d3e069d8e8cb26a14bd10"
 
 [[package]]
+name = "lock_api"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -421,6 +446,31 @@ name = "parity-wasm"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
+
+[[package]]
+name = "parking_lot"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
+dependencies = [
+ "cfg-if 1.0.0",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.10",
+ "smallvec",
+ "winapi",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -494,6 +544,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,6 +595,12 @@ dependencies = [
  "serde_derive_internals",
  "syn",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
@@ -614,7 +679,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2933378ddfeda7ea26f48c555bdad8bb446bf8a3d17832dc83e380d444cfb8c1"
 dependencies = [
  "block-buffer",
- "cfg-if",
+ "cfg-if 0.1.10",
  "cpuid-bool",
  "digest",
  "opaque-debug",
@@ -632,6 +697,12 @@ dependencies = [
  "log",
  "winapi",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "snafu"
@@ -678,10 +749,10 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "rand",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "remove_dir_all",
  "winapi",
 ]

--- a/x/compute/client/utils/utils.go
+++ b/x/compute/client/utils/utils.go
@@ -252,7 +252,7 @@ var re = regexp.MustCompile("encrypted: (.+?):")
 func (ctx WASMContext) DecryptError(errString string, msgType string, nonce []byte) (json.RawMessage, error) {
 	regexMatch := re.FindStringSubmatch(errString)
 	if len(regexMatch) != 2 {
-		return nil, fmt.Errorf("Got an error finding base64 of the error: regexMatch '%v' should have a length of 2", regexMatch)
+		return nil, fmt.Errorf("Got an error finding base64 of the error: regexMatch '%v' should have a length of 2. error: %v", regexMatch, errString)
 	}
 	errorCipherB64 := regexMatch[1]
 


### PR DESCRIPTION
This PR will fix the issue of queries failing with `SGX_ERROR_OUT_OF_TCS` when another query is already running at the same time.
Now, queries will wait for up to 2 seconds to enter the enclave before failing with an error message that says `"Too many queries, please try again"`.