### PR TITLE
Crates io publishing

### DIFF
--- a/cosmwasm/Cargo.lock
+++ b/cosmwasm/Cargo.lock
@@ -148,7 +148,6 @@ name = "cosmwasm-sgx-vm"
 version = "0.10.0"
 dependencies = [
  "base64 0.12.3",
- "cosmwasm-std",
  "enclave-ffi-types",
  "hex",
  "lazy_static",
@@ -157,6 +156,7 @@ dependencies = [
  "parity-wasm",
  "parking_lot",
  "schemars",
+ "secret-cosmwasm-std",
  "serde",
  "serde_json",
  "sgx_types",
@@ -168,22 +168,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cosmwasm-std"
-version = "0.10.0"
-dependencies = [
- "base64 0.11.0",
- "cosmwasm-schema",
- "schemars",
- "serde",
- "serde-json-wasm",
- "snafu",
-]
-
-[[package]]
 name = "cosmwasm-storage"
 version = "0.10.0"
 dependencies = [
- "cosmwasm-std",
+ "secret-cosmwasm-std",
  "serde",
  "snafu",
 ]
@@ -513,6 +501,18 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "secret-cosmwasm-std"
+version = "0.10.0"
+dependencies = [
+ "base64 0.11.0",
+ "cosmwasm-schema",
+ "schemars",
+ "serde",
+ "serde-json-wasm",
+ "snafu",
+]
 
 [[package]]
 name = "serde"

--- a/cosmwasm/Cargo.lock
+++ b/cosmwasm/Cargo.lock
@@ -168,15 +168,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cosmwasm-storage"
-version = "0.10.0"
-dependencies = [
- "secret-cosmwasm-std",
- "serde",
- "snafu",
-]
-
-[[package]]
 name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,6 +502,15 @@ dependencies = [
  "schemars",
  "serde",
  "serde-json-wasm",
+ "snafu",
+]
+
+[[package]]
+name = "secret-cosmwasm-storage"
+version = "0.10.0"
+dependencies = [
+ "secret-cosmwasm-std",
+ "serde",
  "snafu",
 ]
 

--- a/cosmwasm/contracts/burner/Cargo.toml
+++ b/cosmwasm/contracts/burner/Cargo.toml
@@ -35,7 +35,7 @@ cranelift = ["cosmwasm-vm/default-cranelift"]
 singlepass = ["cosmwasm-vm/default-singlepass"]
 
 [dependencies]
-cosmwasm-std = { path = "../../packages/std", features = ["iterator"] }
+cosmwasm-std = { path = "../../packages/std", package = "secret-cosmwasm-std", features = ["iterator"] }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 snafu = { version = "0.6.3" }

--- a/cosmwasm/contracts/debug-print/Cargo.toml
+++ b/cosmwasm/contracts/debug-print/Cargo.toml
@@ -32,7 +32,7 @@ default = []
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cosmwasm-std = { path = "../../packages/std", features = ["iterator", "debug-print"] }
+cosmwasm-std = { path = "../../packages/std", package = "secret-cosmwasm-std", features = ["iterator", "debug-print"] }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 #snafu = { version = "0.6.3" }

--- a/cosmwasm/contracts/dist/Cargo.toml
+++ b/cosmwasm/contracts/dist/Cargo.toml
@@ -31,7 +31,7 @@ overflow-checks = true
 default = []
 
 [dependencies]
-cosmwasm-std = { path = "../../packages/std" }
+cosmwasm-std = { path = "../../packages/std", package = "secret-cosmwasm-std" }
 cosmwasm-storage = { path = "../../packages/storage" }
 schemars = "0.7"
 serde = { version = "=1.0.103", default-features = false, features = [

--- a/cosmwasm/contracts/dist/Cargo.toml
+++ b/cosmwasm/contracts/dist/Cargo.toml
@@ -32,7 +32,7 @@ default = []
 
 [dependencies]
 cosmwasm-std = { path = "../../packages/std", package = "secret-cosmwasm-std" }
-cosmwasm-storage = { path = "../../packages/storage" }
+cosmwasm-storage = { path = "../../packages/storage", package = "secret-cosmwasm-storage" }
 schemars = "0.7"
 serde = { version = "=1.0.103", default-features = false, features = [
   "derive"

--- a/cosmwasm/contracts/erc20/Cargo.toml
+++ b/cosmwasm/contracts/erc20/Cargo.toml
@@ -37,7 +37,7 @@ singlepass = ["cosmwasm-vm/default-singlepass"]
 
 [dependencies]
 cosmwasm-std = { path = "../../packages/std", package = "secret-cosmwasm-std" }
-cosmwasm-storage = { path = "../../packages/storage" }
+cosmwasm-storage = { path = "../../packages/storage", package = "secret-cosmwasm-storage" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 hex = "0.4"

--- a/cosmwasm/contracts/erc20/Cargo.toml
+++ b/cosmwasm/contracts/erc20/Cargo.toml
@@ -36,7 +36,7 @@ cranelift = ["cosmwasm-vm/default-cranelift"]
 singlepass = ["cosmwasm-vm/default-singlepass"]
 
 [dependencies]
-cosmwasm-std = { path = "../../packages/std" }
+cosmwasm-std = { path = "../../packages/std", package = "secret-cosmwasm-std" }
 cosmwasm-storage = { path = "../../packages/storage" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/cosmwasm/contracts/escrow/Cargo.toml
+++ b/cosmwasm/contracts/escrow/Cargo.toml
@@ -37,7 +37,7 @@ singlepass = ["cosmwasm-vm/default-singlepass"]
 
 [dependencies]
 cosmwasm-std = { path = "../../packages/std", package = "secret-cosmwasm-std" }
-cosmwasm-storage = { path = "../../packages/storage" }
+cosmwasm-storage = { path = "../../packages/storage", package = "secret-cosmwasm-storage" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 

--- a/cosmwasm/contracts/escrow/Cargo.toml
+++ b/cosmwasm/contracts/escrow/Cargo.toml
@@ -36,7 +36,7 @@ cranelift = ["cosmwasm-vm/default-cranelift"]
 singlepass = ["cosmwasm-vm/default-singlepass"]
 
 [dependencies]
-cosmwasm-std = { path = "../../packages/std" }
+cosmwasm-std = { path = "../../packages/std", package = "secret-cosmwasm-std" }
 cosmwasm-storage = { path = "../../packages/storage" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/cosmwasm/contracts/gov/Cargo.toml
+++ b/cosmwasm/contracts/gov/Cargo.toml
@@ -31,7 +31,7 @@ overflow-checks = true
 default = []
 
 [dependencies]
-cosmwasm-std = { path = "../../packages/std" }
+cosmwasm-std = { path = "../../packages/std", package = "secret-cosmwasm-std" }
 cosmwasm-storage = { path = "../../packages/storage" }
 schemars = "0.7"
 serde = { version = "1", default-features = false, features = [

--- a/cosmwasm/contracts/gov/Cargo.toml
+++ b/cosmwasm/contracts/gov/Cargo.toml
@@ -32,7 +32,7 @@ default = []
 
 [dependencies]
 cosmwasm-std = { path = "../../packages/std", package = "secret-cosmwasm-std" }
-cosmwasm-storage = { path = "../../packages/storage" }
+cosmwasm-storage = { path = "../../packages/storage", package = "secret-cosmwasm-storage" }
 schemars = "0.7"
 serde = { version = "1", default-features = false, features = [
   "derive"

--- a/cosmwasm/contracts/hackatom/Cargo.toml
+++ b/cosmwasm/contracts/hackatom/Cargo.toml
@@ -28,7 +28,7 @@ cranelift = ["cosmwasm-vm/default-cranelift"]
 singlepass = ["cosmwasm-vm/default-singlepass"]
 
 [dependencies]
-cosmwasm-std = { path = "../../packages/std" }
+cosmwasm-std = { path = "../../packages/std", package = "secret-cosmwasm-std" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 sha2 = "0.9.1"

--- a/cosmwasm/contracts/hackatom/Cargo.toml
+++ b/cosmwasm/contracts/hackatom/Cargo.toml
@@ -35,5 +35,5 @@ sha2 = "0.9.1"
 
 [dev-dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }
-cosmwasm-storage = { path = "../../packages/storage" }
+cosmwasm-storage = { path = "../../packages/storage", package = "secret-cosmwasm-storage" }
 cosmwasm-vm = { path = "../../packages/sgx-vm", package = "cosmwasm-sgx-vm", default-features = false }

--- a/cosmwasm/contracts/mint/Cargo.toml
+++ b/cosmwasm/contracts/mint/Cargo.toml
@@ -31,7 +31,7 @@ overflow-checks = true
 default = []
 
 [dependencies]
-cosmwasm-std = { path = "../../packages/std" }
+cosmwasm-std = { path = "../../packages/std", package = "secret-cosmwasm-std" }
 cosmwasm-storage = { path = "../../packages/storage" }
 schemars = "0.7"
 serde = { version = "=1.0.103", default-features = false, features = [

--- a/cosmwasm/contracts/mint/Cargo.toml
+++ b/cosmwasm/contracts/mint/Cargo.toml
@@ -32,7 +32,7 @@ default = []
 
 [dependencies]
 cosmwasm-std = { path = "../../packages/std", package = "secret-cosmwasm-std" }
-cosmwasm-storage = { path = "../../packages/storage" }
+cosmwasm-storage = { path = "../../packages/storage", package = "secret-cosmwasm-storage" }
 schemars = "0.7"
 serde = { version = "=1.0.103", default-features = false, features = [
   "derive"

--- a/cosmwasm/contracts/plaintext-logs/Cargo.toml
+++ b/cosmwasm/contracts/plaintext-logs/Cargo.toml
@@ -32,7 +32,7 @@ default = []
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cosmwasm-std = { path = "../../packages/std", features = ["iterator"] }
+cosmwasm-std = { path = "../../packages/std", package = "secret-cosmwasm-std", features = ["iterator"] }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 #snafu = { version = "0.6.3" }

--- a/cosmwasm/contracts/queue/Cargo.toml
+++ b/cosmwasm/contracts/queue/Cargo.toml
@@ -29,7 +29,7 @@ cranelift = ["cosmwasm-vm/default-cranelift"]
 singlepass = ["cosmwasm-vm/default-singlepass"]
 
 [dependencies]
-cosmwasm-std = { path = "../../packages/std", features = ["iterator"] }
+cosmwasm-std = { path = "../../packages/std", package = "secret-cosmwasm-std", features = ["iterator"] }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 

--- a/cosmwasm/contracts/reflect/Cargo.toml
+++ b/cosmwasm/contracts/reflect/Cargo.toml
@@ -36,7 +36,7 @@ cranelift = ["cosmwasm-vm/default-cranelift"]
 singlepass = ["cosmwasm-vm/default-singlepass"]
 
 [dependencies]
-cosmwasm-std = { path = "../../packages/std", features = ["staking"] }
+cosmwasm-std = { path = "../../packages/std", package = "secret-cosmwasm-std", features = ["staking"] }
 cosmwasm-storage = { path = "../../packages/storage" }
 schemars = "0.7"
 serde = { version = "^1.0.117", default-features = false, features = [

--- a/cosmwasm/contracts/reflect/Cargo.toml
+++ b/cosmwasm/contracts/reflect/Cargo.toml
@@ -37,7 +37,7 @@ singlepass = ["cosmwasm-vm/default-singlepass"]
 
 [dependencies]
 cosmwasm-std = { path = "../../packages/std", package = "secret-cosmwasm-std", features = ["staking"] }
-cosmwasm-storage = { path = "../../packages/storage" }
+cosmwasm-storage = { path = "../../packages/storage", package = "secret-cosmwasm-storage" }
 schemars = "0.7"
 serde = { version = "^1.0.117", default-features = false, features = [
   "derive"

--- a/cosmwasm/contracts/staking/Cargo.toml
+++ b/cosmwasm/contracts/staking/Cargo.toml
@@ -33,7 +33,7 @@ cranelift = ["cosmwasm-vm/default-cranelift"]
 singlepass = ["cosmwasm-vm/default-singlepass"]
 
 [dependencies]
-cosmwasm-std = { path = "../../packages/std", features = ["staking"] }
+cosmwasm-std = { path = "../../packages/std", package = "secret-cosmwasm-std", features = ["staking"] }
 cosmwasm-storage = { path = "../../packages/storage" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/cosmwasm/contracts/staking/Cargo.toml
+++ b/cosmwasm/contracts/staking/Cargo.toml
@@ -34,7 +34,7 @@ singlepass = ["cosmwasm-vm/default-singlepass"]
 
 [dependencies]
 cosmwasm-std = { path = "../../packages/std", package = "secret-cosmwasm-std", features = ["staking"] }
-cosmwasm-storage = { path = "../../packages/storage" }
+cosmwasm-storage = { path = "../../packages/storage", package = "secret-cosmwasm-storage" }
 schemars = "0.7"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 snafu = { version = "0.6.3" }

--- a/cosmwasm/packages/sgx-vm/Cargo.toml
+++ b/cosmwasm/packages/sgx-vm/Cargo.toml
@@ -39,7 +39,7 @@ debug-print = []
 
 [dependencies]
 # Uses the path when built locally; uses the given version from crates.io when published
-cosmwasm-std = { path = "../std", version = "0.10.0" }
+cosmwasm-std = { path = "../std", package = "secret-cosmwasm-std", version = "0.10.0" }
 serde_json = "1.0"
 # wasmer-runtime-core = "=0.17.0"
 # wasmer-middleware-common = "=0.17.0"

--- a/cosmwasm/packages/std/Cargo.toml
+++ b/cosmwasm/packages/std/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
-name = "cosmwasm-std"
+name = "secret-cosmwasm-std"
 version = "0.10.0"
-authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
+authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>", "SCRT Labs <info@scrtlabs.com>"]
 edition = "2018"
 description = "Standard library for Wasm based smart contracts on Cosmos blockchains"
-repository = "https://github.com/CosmWasm/cosmwasm/tree/master/packages/std"
+repository = "https://github.com/scrtlabs/SecretNetwork/tree/master/cosmwasm/packages/std"
 license = "Apache-2.0"
 readme = "README.md"
 
 [badges]
-circle-ci = { repository = "CosmWasm/cosmwasm", branch = "master" }
+#circle-ci = { repository = "CosmWasm/cosmwasm", branch = "master" }
 maintenance = { status = "actively-developed" }
 
 [features]

--- a/cosmwasm/packages/std/README.md
+++ b/cosmwasm/packages/std/README.md
@@ -1,6 +1,9 @@
-# cosmwasm
+# cosmwasm-std
 
-[![cosmwasm-std on crates.io](https://img.shields.io/crates/v/cosmwasm-std.svg)](https://crates.io/crates/cosmwasm-std)
+[comment]: <> ([![cosmwasm-std on crates.io]&#40;https://img.shields.io/crates/v/cosmwasm-std.svg&#41;]&#40;https://crates.io/crates/cosmwasm-std&#41;)
+
+NOTE: This is a fork of the original cosmwasm-std repository adapted for use in [SecretNetwork](https://scrt.network)'s
+Secret Contracts.
 
 The standard library for building CosmWasm smart contracts. Code in this package
 is compiled into the smart contract.

--- a/cosmwasm/packages/storage/Cargo.toml
+++ b/cosmwasm/packages/storage/Cargo.toml
@@ -1,16 +1,17 @@
 [package]
-name = "cosmwasm-storage"
+name = "secret-cosmwasm-storage"
 version = "0.10.0"
-authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
+authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>", "SCRT Labs <info@scrtlabs.com>"]
 edition = "2018"
 description = "CosmWasm library with useful helpers for Storage patterns"
-repository = "https://github.com/CosmWasm/cosmwasm/tree/master/packages/storage"
+repository = "https://github.com/scrtlabs/SecretNetwork/tree/master/cosmwasm/packages/storage"
 license = "Apache-2.0"
+readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [badges]
-circle-ci = { repository = "CosmWasm/cosmwasm", branch = "master" }
+#circle-ci = { repository = "CosmWasm/cosmwasm", branch = "master" }
 maintenance = { status = "actively-developed" }
 
 [features]

--- a/cosmwasm/packages/storage/Cargo.toml
+++ b/cosmwasm/packages/storage/Cargo.toml
@@ -19,7 +19,7 @@ iterator = ["cosmwasm-std/iterator"]
 
 [dependencies]
 # Uses the path when built locally; uses the given version from crates.io when published
-cosmwasm-std = { path = "../std", version = "0.10.0" }
+cosmwasm-std = { path = "../std", package = "secret-cosmwasm-std", version = "0.10.0" }
 serde = { version = "1.0.103", default-features = false, features = ["derive", "alloc"] }
 
 [dev-dependencies]

--- a/cosmwasm/packages/storage/README.md
+++ b/cosmwasm/packages/storage/README.md
@@ -1,7 +1,10 @@
 # cosmwasm-storage
 
-[![cosmwasm-storage on crates.io](https://img.shields.io/crates/v/cosmwasm-storage.svg)](https://crates.io/crates/cosmwasm-storage)
-[![CircleCI](https://circleci.com/gh/CosmWasm/cosmwasm/tree/master.svg?style=shield)](https://circleci.com/gh/CosmWasm/cosmwasm/tree/master)
+[comment]: <> ([![cosmwasm-storage on crates.io]&#40;https://img.shields.io/crates/v/cosmwasm-storage.svg&#41;]&#40;https://crates.io/crates/cosmwasm-storage&#41;)
+[comment]: <> ([![CircleCI]&#40;https://circleci.com/gh/CosmWasm/cosmwasm/tree/master.svg?style=shield&#41;]&#40;https://circleci.com/gh/CosmWasm/cosmwasm/tree/master&#41;)
+
+NOTE: This is a fork of the original cosmwasm-storage repository adapted for use in [SecretNetwork](https://scrt.network)'s
+Secret Contracts.
 
 CosmWasm library with useful helpers for Storage patterns. You can use `Storage`
 implementations in `cosmwasm-std`, or rely on these to remove some common

--- a/go-cosmwasm/Cargo.lock
+++ b/go-cosmwasm/Cargo.lock
@@ -171,7 +171,6 @@ name = "cosmwasm-sgx-vm"
 version = "0.10.0"
 dependencies = [
  "base64 0.12.3",
- "cosmwasm-std",
  "enclave-ffi-types",
  "hex",
  "lazy_static",
@@ -180,22 +179,12 @@ dependencies = [
  "parity-wasm",
  "parking_lot",
  "schemars",
+ "secret-cosmwasm-std",
  "serde",
  "serde_json",
  "sgx_types",
  "sgx_urts",
  "sha2",
- "snafu",
-]
-
-[[package]]
-name = "cosmwasm-std"
-version = "0.10.0"
-dependencies = [
- "base64 0.11.0",
- "schemars",
- "serde",
- "serde-json-wasm",
  "snafu",
 ]
 
@@ -310,10 +299,10 @@ version = "0.10.0"
 dependencies = [
  "cbindgen 0.14.3",
  "cosmwasm-sgx-vm",
- "cosmwasm-std",
  "ctor",
  "errno",
  "log",
+ "secret-cosmwasm-std",
  "serde",
  "serde_json",
  "sgx_edl",
@@ -601,6 +590,17 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "secret-cosmwasm-std"
+version = "0.10.0"
+dependencies = [
+ "base64 0.11.0",
+ "schemars",
+ "serde",
+ "serde-json-wasm",
+ "snafu",
+]
 
 [[package]]
 name = "serde"

--- a/go-cosmwasm/Cargo.toml
+++ b/go-cosmwasm/Cargo.toml
@@ -33,7 +33,7 @@ production = ["cosmwasm-sgx-vm/production"]
 debug-print = ["cosmwasm-sgx-vm/debug-print"]
 
 [dependencies]
-cosmwasm-std = { path = "../cosmwasm/packages/std", features = ["iterator"] }
+cosmwasm-std = { path = "../cosmwasm/packages/std", package = "secret-cosmwasm-std", features = ["iterator"] }
 cosmwasm-sgx-vm = { path = "../cosmwasm/packages/sgx-vm", features = [
     "iterator"
 ] }

--- a/x/compute/internal/keeper/testdata/test-contract/Cargo.toml
+++ b/x/compute/internal/keeper/testdata/test-contract/Cargo.toml
@@ -32,7 +32,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 with_floats = []
 
 [dependencies]
-cosmwasm-std = { path = "../../../../../../cosmwasm/packages/std" }
+cosmwasm-std = { path = "../../../../../../cosmwasm/packages/std", package = "secret-cosmwasm-std" }
 cosmwasm-storage = { path = "../../../../../../cosmwasm/packages/storage" }
 schemars = "0.7"
 serde = { version = "1.0.114", default-features = false, features = [

--- a/x/compute/internal/keeper/testdata/test-contract/Cargo.toml
+++ b/x/compute/internal/keeper/testdata/test-contract/Cargo.toml
@@ -33,7 +33,7 @@ with_floats = []
 
 [dependencies]
 cosmwasm-std = { path = "../../../../../../cosmwasm/packages/std", package = "secret-cosmwasm-std" }
-cosmwasm-storage = { path = "../../../../../../cosmwasm/packages/storage" }
+cosmwasm-storage = { path = "../../../../../../cosmwasm/packages/storage", package = "secret-cosmwasm-storage" }
 schemars = "0.7"
 serde = { version = "1.0.114", default-features = false, features = [
   "derive",


### PR DESCRIPTION
I published the latest version of our cosmasm-std to crates.io here:

https://crates.io/crates/secret-cosmwasm-std

To use it, you can import it like so:
```toml
cosmwasm-std = { package = "secret-cosmwasm-std", version = "0.10.0" }
```

The latest commit here is also tagged as `secret-cosmwasm-v0.10.0`

Coming to `secret-toolkit` soon!