### PR TITLE
Support old CPUs in `SGX_MODE=SW`

### DIFF
--- a/cosmwasm/enclaves/execute/Makefile
+++ b/cosmwasm/enclaves/execute/Makefile
@@ -96,7 +96,7 @@ Rust_Crate_Source := $(shell find -type f | grep -vP '(\.so|\.o|\.a)$$' | grep -
 Rust_Target_Path := $(CURDIR)/../xargo
 
 ifeq ($(SGX_MODE), SW)
-	Rust_Flags := "-Z force-unstable-if-unmarked -C target-feature=+aes,+ssse3"
+	Rust_Flags := "-Z force-unstable-if-unmarked"
 else
 	Rust_Flags := "-Z force-unstable-if-unmarked -C target-cpu=skylake"
 endif

--- a/cosmwasm/enclaves/query/Makefile
+++ b/cosmwasm/enclaves/query/Makefile
@@ -96,7 +96,7 @@ Rust_Crate_Source := $(shell find -type f | grep -vP '(\.so|\.o|\.a)$$' | grep -
 Rust_Target_Path := $(CURDIR)/../xargo
 
 ifeq ($(SGX_MODE), SW)
-	Rust_Flags := "-Z force-unstable-if-unmarked -C target-feature=+aes,+ssse3"
+	Rust_Flags := "-Z force-unstable-if-unmarked"
 else
 	Rust_Flags := "-Z force-unstable-if-unmarked -C target-cpu=skylake"
 endif

--- a/cosmwasm/enclaves/shared/contract-engine/Makefile
+++ b/cosmwasm/enclaves/shared/contract-engine/Makefile
@@ -1,7 +1,7 @@
 SGX_MODE ?= HW
 
 ifeq ($(SGX_MODE), SW)
-	Rust_Flags := "-Z force-unstable-if-unmarked -C target-feature=+aes,+ssse3"
+	Rust_Flags := "-Z force-unstable-if-unmarked"
 else
 	Rust_Flags := "-Z force-unstable-if-unmarked -C target-cpu=skylake"
 endif

--- a/cosmwasm/enclaves/shared/cosmos-types/Makefile
+++ b/cosmwasm/enclaves/shared/cosmos-types/Makefile
@@ -1,7 +1,7 @@
 SGX_MODE ?= HW
 
 ifeq ($(SGX_MODE), SW)
-	Rust_Flags := "-Z force-unstable-if-unmarked -C target-feature=+aes,+ssse3"
+	Rust_Flags := "-Z force-unstable-if-unmarked"
 else
 	Rust_Flags := "-Z force-unstable-if-unmarked -C target-cpu=skylake"
 endif

--- a/cosmwasm/enclaves/shared/cosmwasm-types/Makefile
+++ b/cosmwasm/enclaves/shared/cosmwasm-types/Makefile
@@ -1,7 +1,7 @@
 SGX_MODE ?= HW
 
 ifeq ($(SGX_MODE), SW)
-	Rust_Flags := "-Z force-unstable-if-unmarked -C target-feature=+aes,+ssse3"
+	Rust_Flags := "-Z force-unstable-if-unmarked"
 else
 	Rust_Flags := "-Z force-unstable-if-unmarked -C target-cpu=skylake"
 endif

--- a/cosmwasm/enclaves/shared/crypto/Makefile
+++ b/cosmwasm/enclaves/shared/crypto/Makefile
@@ -1,7 +1,7 @@
 SGX_MODE ?= HW
 
 ifeq ($(SGX_MODE), SW)
-	Rust_Flags := "-Z force-unstable-if-unmarked -C target-feature=+aes,+ssse3"
+	Rust_Flags := "-Z force-unstable-if-unmarked"
 else
 	Rust_Flags := "-Z force-unstable-if-unmarked -C target-cpu=skylake"
 endif

--- a/cosmwasm/enclaves/shared/utils/Makefile
+++ b/cosmwasm/enclaves/shared/utils/Makefile
@@ -1,7 +1,7 @@
 SGX_MODE ?= HW
 
 ifeq ($(SGX_MODE), SW)
-	Rust_Flags := "-Z force-unstable-if-unmarked -C target-feature=+aes,+ssse3"
+	Rust_Flags := "-Z force-unstable-if-unmarked"
 else
 	Rust_Flags := "-Z force-unstable-if-unmarked -C target-cpu=skylake"
 endif


### PR DESCRIPTION
Support old CPUs in `SGX_MODE=SW` by removing `-C target-feature=+aes,+ssse3` when building.