### PR TITLE
Port dev image faucet from python to node #961

### DIFF
--- a/deployment/docker/devimage/bootstrap_init_no_stop.sh
+++ b/deployment/docker/devimage/bootstrap_init_no_stop.sh
@@ -65,7 +65,7 @@ perl -i -pe 's/enable-unsafe-cors = false/enable-unsafe-cors = true/' .secretd/c
 lcp --proxyUrl http://localhost:1316 --port 1317 --proxyPartial '' &
 
 # Setup faucet
-nohup node faucet_server.js >/dev/null 2>&1 &
+setsid node faucet_server.js &
 
 # Setup secretcli
 cp $(which secretd) $(dirname $(which secretd))/secretcli


### PR DESCRIPTION
@assafmo switched to setsid, left the stdout unchanged.
Works as expected even after errors like invalid checksum address

Let me know if there's anywhere I should add some tests and I'll take a look