### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/x/registration/internal/keeper/genesis_test.go
+++ b/x/registration/internal/keeper/genesis_test.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/enigmampc/SecretNetwork/x/registration/internal/types"
@@ -11,9 +10,7 @@ import (
 )
 
 func TestInitGenesisNoMaster(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "wasm")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	ctx, keeper := CreateTestInput(t, false, tempDir, true)
 	//
 	//cert, err := ioutil.ReadFile("../../testdata/attestation_cert")
@@ -29,9 +26,7 @@ func TestInitGenesisNoMaster(t *testing.T) {
 }
 
 func TestInitGenesis(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "wasm")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	ctx, keeper := CreateTestInput(t, false, tempDir, true)
 
 	cert, err := ioutil.ReadFile("../../testdata/attestation_cert_sw")
@@ -47,9 +42,7 @@ func TestInitGenesis(t *testing.T) {
 }
 
 func TestExportGenesis(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "wasm")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	ctx, keeper := CreateTestInput(t, false, tempDir, true)
 
 	cert, err := ioutil.ReadFile("../../testdata/attestation_cert_sw")

--- a/x/registration/internal/keeper/keeper_test.go
+++ b/x/registration/internal/keeper/keeper_test.go
@@ -22,21 +22,17 @@ func init() {
 }
 
 func TestNewKeeper(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "reg")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	_, regKeeper := CreateTestInput(t, false, tempDir, true)
 	require.NotNil(t, regKeeper)
 }
 
 func TestNewKeeper_Node(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "reg")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	seedPath := filepath.Join(tempDir, types.SecretNodeCfgFolder, types.SecretNodeSeedConfig)
 
-	err = os.MkdirAll(filepath.Join(tempDir, types.SecretNodeCfgFolder), 0o700)
+	err := os.MkdirAll(filepath.Join(tempDir, types.SecretNodeCfgFolder), 0o700)
 	require.NoError(t, err)
 
 	err = ioutil.WriteFile(seedPath, CreateTestSeedConfig(t), 0o700)
@@ -47,9 +43,7 @@ func TestNewKeeper_Node(t *testing.T) {
 }
 
 func TestKeeper_RegisterationStore(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "wasm")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	ctx, regKeeper := CreateTestInput(t, false, tempDir, true)
 
 	cert, err := ioutil.ReadFile("../../testdata/attestation_cert_sw")
@@ -73,9 +67,7 @@ func TestKeeper_RegisterationStore(t *testing.T) {
 }
 
 func TestKeeper_RegisterNode(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "wasm")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	ctx, regKeeper := CreateTestInput(t, false, tempDir, true)
 
 	cert, err := ioutil.ReadFile("../../testdata/attestation_cert_sw")

--- a/x/registration/internal/keeper/querier_test.go
+++ b/x/registration/internal/keeper/querier_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"io/ioutil"
-	"os"
 	"testing"
 
 	sdkErrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -18,9 +17,7 @@ import (
 )
 
 func TestNewQuerier(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "wasm")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	ctx, keeper := CreateTestInput(t, false, tempDir, true)
 
 	nodeIdInvalid := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	require.NoError(t, err)
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```