### PR TITLE
go-1.19

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "^1.18" # The Go version to download (if necessary) and use.
+          go-version: 1.19 # The Go version to download (if necessary) and use.
       - name: Install Intel's SGX SDK
         run: |
           mkdir -p "$HOME/.sgxsdk"
@@ -166,7 +166,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "^1.18" # The Go version to download (if necessary) and use.
+          go-version: 1.19 # The Go version to download (if necessary) and use.
       - name: Install Intel's SGX SDK
         run: |
           mkdir -p "$HOME/.sgxsdk"
@@ -280,7 +280,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "^1.18" # The Go version to download (if necessary) and use.
+          go-version: 1.19 # The Go version to download (if necessary) and use.
       - name: Install xgo
         run: |
           go install github.com/crazy-max/xgo@latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
           echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
       - uses: actions/setup-go@v2
         with:
-          go-version: "^1.18" # The Go version to download (if necessary) and use.
+          go-version: 1.19 # The Go version to download (if necessary) and use.
       - name: Install Intel's SGX SDK
         run: |
           mkdir -p "$HOME/.sgxsdk"
@@ -97,7 +97,7 @@ jobs:
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
       - uses: actions/setup-go@v2
         with:
-          go-version: "^1.18" # The Go version to download (if necessary) and use.
+          go-version: 1.19 # The Go version to download (if necessary) and use.
       - name: Create api keys
         run: |
           echo $SPID_MAINNET > spid.txt
@@ -144,7 +144,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v2
         with:
-          go-version: "^1.18" # The Go version to download (if necessary) and use.
+          go-version: 1.19 # The Go version to download (if necessary) and use.
       - name: Install xgo
         run: |
           go install github.com/crazy-max/xgo@latest


### PR DESCRIPTION
uses go 1.19 for github ci

this is the original reason for #1066 