### PR TITLE
Fix possible null-dref

### DIFF
--- a/x/compute/internal/keeper/keeper.go
+++ b/x/compute/internal/keeper/keeper.go
@@ -235,6 +235,10 @@ func (k Keeper) GetSignerInfo(ctx sdk.Context, signer sdk.AccAddress) ([]byte, s
 	}
 
 	signatures, err := protobufTx.GetSignaturesV2()
+	if err != nil {
+		return nil, 0, nil, nil, nil, sdkerrors.Wrap(types.ErrSigFailed, fmt.Sprintf("Unable to get signatures v2: %s", err.Error()))
+	}
+
 	var signMode sdktxsigning.SignMode
 	switch signData := signatures[pkIndex].Data.(type) {
 	case *sdktxsigning.SingleSignatureData:


### PR DESCRIPTION
`GetSignaturesV2` can return err which means `signatures` gonna be null now when drefing `signatures` in line 243: `signatures[pkIndex]` it might crash