### PR TITLE
Fix v010 DistQuery::Rewards bug

### DIFF
--- a/go-cosmwasm/types/queries.go
+++ b/go-cosmwasm/types/queries.go
@@ -469,8 +469,8 @@ type RewardsQuery struct {
 
 // DelegationResponse is the expected response to DelegationsQuery
 type RewardsResponse struct {
-	Rewards []Rewards   `json:"rewards,omitempty"`
-	Total   RewardCoins `json:"total,omitempty"`
+	Rewards []Rewards   `json:"rewards"`
+	Total   RewardCoins `json:"total"`
 }
 
 type Rewards struct {


### PR DESCRIPTION
When making a DistQuery::Rewards, where the delegator does not have any pending rewards the query returns null for rewards. e.g. {"rewards":null,"total":[]}
The desired result is to return an empty vector in such a case; e.g. {"rewards":[],"total":[]}

*I will change the fix to be more pretty in an upcoming update