### PR TITLE
Refactor Tendermint and Cosmos configs

### DIFF
--- a/cmd/secretd/config.go
+++ b/cmd/secretd/config.go
@@ -31,11 +31,15 @@ func initAppConfig() (string, interface{}) {
 	//   own app.toml to override, or use this default value.
 	//
 	// In simapp, we set the min gas prices to 0.
+	// Assaf: This changes the default if the config is not present at all
+	// (E.g. a new config after a chain upgrade)
 	srvCfg.MinGasPrices = "0.0125uscrt"
 	srvCfg.API.Enable = true
 	srvCfg.API.Swagger = true
 	srvCfg.API.EnableUnsafeCORS = true
-	srvCfg.IAVLCacheSize = 781_250
+	srvCfg.GRPCWeb.Enable = true
+	srvCfg.GRPCWeb.EnableUnsafeCORS = true
+	srvCfg.IAVLCacheSize = 781_250 // 50 MiB
 
 	secretAppConfig := SecretAppConfig{
 		Config:     *srvCfg,

--- a/cmd/secretd/init.go
+++ b/cmd/secretd/init.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cosmos/go-bip39"
 	"github.com/pkg/errors"
+	"github.com/scrtlabs/SecretNetwork/x/compute"
 	"github.com/spf13/cobra"
 	tmconfig "github.com/tendermint/tendermint/config"
 
@@ -90,6 +91,12 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 				return err
 			}
 
+			// Secret Network config (also part of .secretd/config/app.toml)
+			secretConfig := SecretAppConfig{
+				Config:     cosmosConfig,
+				WASMConfig: *compute.DefaultWasmConfig(),
+			}
+
 			chainID, _ := cmd.Flags().GetString(flags.FlagChainID)
 			if chainID == "" {
 				chainID = fmt.Sprintf("test-chain-%s", tmrand.Str(6))
@@ -113,7 +120,7 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 			tmConfig.FastSync.Version = "v0"
 
 			// Assaf: This changes the default when creating app.toml in `secretd init` (E.g. on a new node)
-			cosmosConfig.IAVLDisableFastNode = false
+			secretConfig.IAVLDisableFastNode = false
 
 			// Get bip39 mnemonic
 			var mnemonic string
@@ -173,7 +180,7 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 			toPrint := newPrintInfo(tmConfig.Moniker, chainID, nodeID, "", appState)
 
 			tmconfig.WriteConfigFile(filepath.Join(tmConfig.RootDir, "config", "config.toml"), tmConfig)
-			sdkconfig.WriteConfigFile(filepath.Join(tmConfig.RootDir, "config", "app.toml"), cosmosConfig)
+			sdkconfig.WriteConfigFile(filepath.Join(tmConfig.RootDir, "config", "app.toml"), secretConfig)
 			return displayInfo(toPrint)
 		},
 	}

--- a/cmd/secretd/init.go
+++ b/cmd/secretd/init.go
@@ -85,15 +85,9 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 			tmConfig := serverCtx.Config
 			tmConfig.SetRoot(clientCtx.HomeDir)
 
-			// Cosmos config (.secretd/config/app.toml)
-			cosmosConfig, err := sdkconfig.GetConfig(serverCtx.Viper)
-			if err != nil {
-				return err
-			}
-
-			// Secret Network config (also part of .secretd/config/app.toml)
+			// Secret Network config (.secretd/config/app.toml)
 			secretConfig := SecretAppConfig{
-				Config:     cosmosConfig,
+				Config:     *sdkconfig.DefaultConfig(),
 				WASMConfig: *compute.DefaultWasmConfig(),
 			}
 

--- a/cmd/secretd/root.go
+++ b/cmd/secretd/root.go
@@ -306,6 +306,8 @@ func newApp(logger log.Logger, db dbm.DB, traceStore io.Writer, appOpts serverty
 		baseapp.SetSnapshotStore(snapshotStore),
 		baseapp.SetSnapshotInterval(cast.ToUint64(appOpts.Get(server.FlagStateSyncSnapshotInterval))),
 		baseapp.SetSnapshotKeepRecent(cast.ToUint32(appOpts.Get(server.FlagStateSyncSnapshotKeepRecent))),
+		baseapp.SetIAVLCacheSize(cast.ToInt(appOpts.Get(server.FlagIAVLCacheSize))),
+		baseapp.SetIAVLDisableFastNode(cast.ToBool(appOpts.Get(server.FlagIAVLFastNode))),
 	)
 }
 


### PR DESCRIPTION
- Code comments
- Override default `GRPCWeb.Enable` to `true`
- Override default `GRPCWeb.EnableUnsafeCORS` to `true`
- On a new node set `IAVLDisableFastNode` to `false`