### PR TITLE
Register the node service

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
+	nodeservice "github.com/cosmos/cosmos-sdk/client/grpc/node"
 	"github.com/cosmos/cosmos-sdk/client/grpc/tmservice"
 	"github.com/cosmos/cosmos-sdk/client/rpc"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -175,6 +176,10 @@ func (app *SecretNetworkApp) RegisterTxService(clientCtx client.Context) {
 
 func (app *SecretNetworkApp) RegisterTendermintService(clientCtx client.Context) {
 	tmservice.RegisterTendermintService(app.BaseApp.GRPCQueryRouter(), clientCtx, app.interfaceRegistry)
+}
+
+func (app *SecretNetworkApp) RegisterNodeService(clientCtx client.Context) {
+	nodeservice.RegisterNodeService(clientCtx, app.GRPCQueryRouter())
 }
 
 // WasmWrapper allows us to use namespacing in the config file


### PR DESCRIPTION
I.e. this registers the `/cosmos/base/node/v1beta1/config` query

This is being called here https://github.com/scrtlabs/cosmos-sdk/blob/ae915c4024/server/start.go#L313-L315

This is not consensus breaking.