### PR TITLE
Match buildarg CHAINID in Makefile with Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,7 @@ localsecret:
 			--build-arg SGX_MODE=SW \
 			$(DOCKER_BUILD_ARGS) \
  			--build-arg SECRET_NODE_TYPE=BOOTSTRAP \
- 			--build-arg CHAIN_ID=secretdev-1 \
+			--build-arg CHAINID=secretdev-1 \
  			-f deployment/dockerfiles/Dockerfile \
  			--target build-localsecret \
  			-t ghcr.io/scrtlabs/localsecret:${DOCKER_TAG} .


### PR DESCRIPTION
Unless I'm missing something the build arg in the Dockerfile is `CHAINID` meanwhile the Makefile uses `CHAIN_ID`.

This pull request changes the Makefile, meaning that `CHAINID` is chosen. If `CHAIN_ID` is preferred then I can change the Dockerfile instead. Just let me know.