### PR TITLE
Remove unused ARG for base image in Dockerfile

### DIFF
--- a/deployment/dockerfiles/Dockerfile
+++ b/deployment/dockerfiles/Dockerfile
@@ -7,7 +7,6 @@
 #   `--target build-deb-mainnet` - the image used to generate deb package for mainnet (will pull precompiled enclave)
 #   `--target compile-secretd` - image with compiled enclave and secretd
 
-ARG SCRT_BASE_IMAGE_SECRETD=enigmampc/rocksdb:v6.24.2-1.1.5
 ARG TEST=enigmampc/rocksdb:v6.24.2
 ARG SCRT_BASE_IMAGE_ENCLAVE=enigmampc/rocksdb:v6.24.2-1.1.5
 ARG SCRT_RELEASE_BASE_IMAGE=enigmampc/enigma-sgx-base:2004-1.1.5


### PR DESCRIPTION
`ARG SCRT_BASE_IMAGE_SECRETD=enigmampc/rocksdb:v6.24.2-1.1.5` is not used in the `deployment/dockerfiles/Dockerfile`