### PR TITLE
moving the counter incrementation or height reset to before the handl…

### DIFF
--- a/cosmwasm/enclaves/shared/contract-engine/src/contract_operations.rs
+++ b/cosmwasm/enclaves/shared/contract-engine/src/contract_operations.rs
@@ -155,12 +155,12 @@ pub fn init(
         debug!("New random: {:?}", versioned_env.get_random());
     }
 
+    update_msg_counter(block_height);
     //let start = Instant::now();
     let result = engine.init(&versioned_env, validated_msg);
     // let duration = start.elapsed();
     // trace!("Time elapsed in engine.init: {:?}", duration);
 
-    update_msg_counter(block_height);
     *used_gas = engine.gas_used();
 
     let output = result?;
@@ -322,10 +322,10 @@ pub fn handle(
 
     versioned_env.set_contract_hash(&contract_hash);
 
+    update_msg_counter(block_height);
     let result = engine.handle(&versioned_env, validated_msg, &parsed_handle_type);
 
     *used_gas = engine.gas_used();
-    update_msg_counter(block_height);
 
     let mut output = result?;
 

--- a/cosmwasm/enclaves/shared/contract-engine/src/random.rs
+++ b/cosmwasm/enclaves/shared/contract-engine/src/random.rs
@@ -54,7 +54,7 @@ pub fn update_msg_counter(height: u64) {
 
     if counter.height != height {
         counter.height = height;
-        counter.counter = 1;
+        counter.counter = 0;
     } else {
         counter.counter += 1;
     }


### PR DESCRIPTION
moving the counter incrementation or height reset to before the handl…e, so that re-writes on read_db will not differ for nodes that just did a restart, also resetting it to 0 now that it's before the handle