### PR TITLE
Update secret-contract-optimizer.Dockerfile

### DIFF
--- a/deployment/dockerfiles/base-images/secret-contract-optimizer.Dockerfile
+++ b/deployment/dockerfiles/base-images/secret-contract-optimizer.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.67.1-slim-bullseye
+FROM rust:1.68.0-slim-bullseye
 
 RUN rustup target add wasm32-unknown-unknown
 RUN apt update && apt install -y binaryen clang && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Just another rust version update: `1.67.1-slim-bullseye` -> `1.68.0-slim-bullseye`

`1.68.0` produces smaller wasm outputs when I build locally than `1.67.1`