### PR TITLE
secret-contract-optimizer: support multiple contracts

### DIFF
--- a/deployment/dockerfiles/base-images/secret-contract-optimizer.Dockerfile
+++ b/deployment/dockerfiles/base-images/secret-contract-optimizer.Dockerfile
@@ -1,8 +1,15 @@
-FROM rust:1.68.0-slim-bullseye
+FROM rust:1.69.0-slim-bullseye
 
 RUN rustup target add wasm32-unknown-unknown
 RUN apt update && apt install -y binaryen clang && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /contract
 
-ENTRYPOINT ["/bin/bash", "-c", "RUSTFLAGS='-C link-arg=-s' cargo build --release --target wasm32-unknown-unknown --locked && wasm-opt -Oz ./target/wasm32-unknown-unknown/release/*.wasm -o ./contract.wasm && cat ./contract.wasm | gzip -n -9 > ./contract.wasm.gz && rm -f ./contract.wasm"]
+ENTRYPOINT ["/bin/bash", "-c", "\
+    RUSTFLAGS='-C link-arg=-s' cargo build --release --target wasm32-unknown-unknown --locked && \
+    (mkdir -p ./optimized-wasm/ && rm -f ./optimized-wasm/* && cp ./target/wasm32-unknown-unknown/release/*.wasm ./optimized-wasm/) && \
+    for w in ./optimized-wasm/*.wasm; do \
+        wasm-opt -Oz $w -o $w ; \
+    done && \
+    (cd ./optimized-wasm && gzip -n -9 -f * && rm *.wasm) \
+"]

--- a/deployment/dockerfiles/base-images/secret-contract-optimizer.Dockerfile
+++ b/deployment/dockerfiles/base-images/secret-contract-optimizer.Dockerfile
@@ -11,5 +11,5 @@ ENTRYPOINT ["/bin/bash", "-c", "\
     for w in ./optimized-wasm/*.wasm; do \
         wasm-opt -Oz $w -o $w ; \
     done && \
-    (cd ./optimized-wasm && gzip -n -9 -f * && rm *.wasm) \
+    (cd ./optimized-wasm && gzip -n -9 -f *) \
 "]


### PR DESCRIPTION
Currently the `secret-contract-optimizer` only supports a single contract, not multiple contracts in a workspace. This updates the script in the Dockerfile to copy all built wasm files to a folder in the root of the project called `optimized-wasm` (naming up for debate). It then loops through them and runs `wasm-opt` each copied wasm. Then finally gzips them all and deletes them.

Also, I updated rust to 1.69.0... [rust 1.70.0 is not working](https://github.com/CosmWasm/cosmwasm/issues/1727)