### PR TITLE
Block cache rollback integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,13 @@ build-linux: _build-linux build_local_no_rust build_cli
 _build-linux:
 	BUILD_PROFILE=$(BUILD_PROFILE) FEATURES=$(FEATURES) FEATURES_U=$(FEATURES_U) $(MAKE) -C go-cosmwasm build-rust
 
+.PHONY: run-dev
+run-dev: docs/tendermint_enclave.signed.so
+	FEATURES="read-db-proofs" SGX_MODE=SW $(MAKE) build-linux
+	cp go-cosmwasm/librust_cosmwasm_enclave.signed.so .
+	cp docs/tendermint_enclave.signed.so .
+	SGX_MODE=SW ./scripts/start-node.sh
+
 build-linux-with-query: _build-linux-with-query build_local_no_rust build_cli
 _build-linux-with-query:
 	BUILD_PROFILE=$(BUILD_PROFILE) FEATURES=$(FEATURES) FEATURES_U=query-node,$(FEATURES_U) $(MAKE) -C go-cosmwasm build-rust

--- a/cosmwasm/enclaves/shared/block-verifier/src/submit_block_signatures.rs
+++ b/cosmwasm/enclaves/shared/block-verifier/src/submit_block_signatures.rs
@@ -153,7 +153,7 @@ pub unsafe fn submit_block_signatures_impl(
         if header.header.height.value() != 1 && rp.app_hash != header.header.app_hash.as_bytes() {
             error!("error verifying app hash!");
             debug!("calculated app_hash bytes {:?}", rp.app_hash);
-            debug!("header app_hash bytes {:?}", header.app_hash.as_bytes());
+            // debug!("header app_hash bytes {:?}", header.app_hash.as_bytes());
             return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
         }
     }

--- a/integration-tests/contract-v0.10/src/contract.rs
+++ b/integration-tests/contract-v0.10/src/contract.rs
@@ -1,8 +1,4 @@
-use cosmwasm_std::{
-    to_binary, Api, BalanceResponse, BankMsg, BankQuery, Binary, Coin, CosmosMsg, Empty, Env,
-    Extern, GovMsg, HandleResponse, HandleResult, HumanAddr, InitResponse, InitResult,
-    LogAttribute, Querier, QueryRequest, QueryResult, StakingMsg, Storage, VoteOption, WasmMsg,
-};
+use cosmwasm_std::{to_binary, Api, BalanceResponse, BankMsg, BankQuery, Binary, Coin, CosmosMsg, Empty, Env, Extern, GovMsg, HandleResponse, HandleResult, HumanAddr, InitResponse, InitResult, LogAttribute, Querier, QueryRequest, QueryResult, StakingMsg, Storage, VoteOption, WasmMsg, Uint128, StdError};
 
 /////////////////////////////// Messages ///////////////////////////////
 
@@ -56,6 +52,12 @@ pub enum Msg {
         send: Vec<Coin>,
     },
     CustomMsg {},
+    Forward {
+        recipient_address: HumanAddr,
+        recipient_hash: String,
+        msg: Binary,
+    },
+    FailTx {}
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -71,6 +73,7 @@ pub fn init<S: Storage, A: Api, Q: Querier>(
     _env: Env,
     _msg: Msg,
 ) -> InitResult {
+    deps.storage.set("forwarded".as_bytes(), "no-fail".as_bytes());
     return Ok(InitResponse {
         messages: vec![],
         log: vec![],
@@ -80,7 +83,7 @@ pub fn init<S: Storage, A: Api, Q: Querier>(
 /////////////////////////////// Handle ///////////////////////////////
 
 pub fn handle<S: Storage, A: Api, Q: Querier>(
-    _deps: &mut Extern<S, A, Q>,
+    deps: &mut Extern<S, A, Q>,
     env: Env,
     msg: Msg,
 ) -> HandleResult {
@@ -192,6 +195,22 @@ pub fn handle<S: Storage, A: Api, Q: Querier>(
             log: vec![],
             data: None,
         }),
+        Msg::Forward { recipient_address, recipient_hash, msg } => {
+            deps.storage.set("forwarded".as_bytes(), "forwarded".as_bytes());
+            Ok(HandleResponse {
+                messages: vec![CosmosMsg::Wasm(
+                    WasmMsg::Execute {
+                        contract_addr: recipient_address,
+                        callback_code_hash: recipient_hash,
+                        msg,
+                        send: vec![]
+                    },
+                )],
+                log: vec![],
+                data: None,
+            })
+        }
+        Msg::FailTx {} => Err (StdError::generic_err("this should always fail")),
     }
 }
 

--- a/integration-tests/contract-v0.10/src/contract.rs
+++ b/integration-tests/contract-v0.10/src/contract.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{to_binary, Api, BalanceResponse, BankMsg, BankQuery, Binary, Coin, CosmosMsg, Empty, Env, Extern, GovMsg, HandleResponse, HandleResult, HumanAddr, InitResponse, InitResult, LogAttribute, Querier, QueryRequest, QueryResult, StakingMsg, Storage, VoteOption, WasmMsg, Uint128, StdError};
+use cosmwasm_std::{to_binary, Api, BalanceResponse, BankMsg, BankQuery, Binary, Coin, CosmosMsg, Empty, Env, Extern, GovMsg, HandleResponse, HandleResult, HumanAddr, InitResponse, InitResult, LogAttribute, Querier, QueryRequest, QueryResult, StakingMsg, Storage, VoteOption, WasmMsg, StdError};
 
 /////////////////////////////// Messages ///////////////////////////////
 
@@ -64,12 +64,13 @@ pub enum Msg {
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
     BankBalance { address: HumanAddr, denom: String },
+    Forward {},
 }
 
 /////////////////////////////// Init ///////////////////////////////
 
 pub fn init<S: Storage, A: Api, Q: Querier>(
-    _deps: &mut Extern<S, A, Q>,
+    deps: &mut Extern<S, A, Q>,
     _env: Env,
     _msg: Msg,
 ) -> InitResult {
@@ -227,5 +228,7 @@ pub fn query<S: Storage, A: Api, Q: Querier>(deps: &Extern<S, A, Q>, msg: QueryM
                     }))?;
             return Ok(to_binary(&res)?);
         }
+        QueryMsg::Forward { } => Ok(to_binary(&deps.storage.get("forwarded".as_bytes()))?),
     }
+
 }

--- a/integration-tests/contract-v1/src/contract.rs
+++ b/integration-tests/contract-v1/src/contract.rs
@@ -1,12 +1,5 @@
 use crate::ibc::PACKET_LIFETIME;
-use cosmwasm_std::{
-    entry_point, to_binary, to_vec, AllBalanceResponse, AllDelegationsResponse,
-    AllValidatorsResponse, BalanceResponse, BankMsg, BankQuery, Binary, BondedDenomResponse,
-    ChannelResponse, ContractInfoResponse, ContractResult, CosmosMsg, DelegationResponse, Deps,
-    DepsMut, DistributionMsg, Empty, Env, Event, GovMsg, IbcMsg, IbcQuery, IbcTimeout,
-    ListChannelsResponse, MessageInfo, PortIdResponse, QueryRequest, Response, StakingMsg,
-    StakingQuery, StdError, StdResult, ValidatorResponse, WasmMsg, WasmQuery,
-};
+use cosmwasm_std::{entry_point, to_binary, to_vec, AllBalanceResponse, AllDelegationsResponse, AllValidatorsResponse, BalanceResponse, BankMsg, BankQuery, Binary, BondedDenomResponse, ChannelResponse, ContractInfoResponse, ContractResult, CosmosMsg, DelegationResponse, Deps, DepsMut, DistributionMsg, Empty, Env, Event, GovMsg, IbcMsg, IbcQuery, IbcTimeout, ListChannelsResponse, MessageInfo, PortIdResponse, QueryRequest, Response, StakingMsg, StakingQuery, StdError, StdResult, ValidatorResponse, WasmMsg, WasmQuery, SubMsg};
 
 use crate::msg::{Msg, PacketMsg, QueryMsg};
 use crate::state::{
@@ -181,6 +174,20 @@ fn handle_msg(deps: DepsMut, env: Env, info: MessageInfo, msg: Msg) -> StdResult
                 ))
             }
         },
+        Msg::Forward { recipient_address, recipient_hash, msg } => {
+            deps.storage.set("forwarded".as_bytes(), "forwarded".as_bytes());
+            Ok(Response::new().add_submessage(SubMsg::new(
+                CosmosMsg::Wasm(
+                    WasmMsg::Execute {
+                        contract_addr: recipient_address.into_string(),
+                        code_hash: recipient_hash,
+                        msg: msg?,
+                        funds: vec![],
+                    },
+                )
+            )))
+        }
+        Msg::FailTx {} => Err (StdError::generic_err("this should always fail")),
         // Msg::GetRandom {} => {
         //     return Ok(
         //         Response::new()

--- a/integration-tests/contract-v1/src/msg.rs
+++ b/integration-tests/contract-v1/src/msg.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Binary, Coin, IbcTimeout, VoteOption};
+use cosmwasm_std::{Addr, Binary, Coin, IbcTimeout, Uint128, VoteOption};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -72,6 +72,12 @@ pub enum Msg {
         funds: Vec<Coin>,
     },
     GetTxId {},
+    Forward {
+        recipient_address: Addr,
+        recipient_hash: String,
+        msg: Option<Binary>,
+    },
+    FailTx {}
     //GetRandom {},
 }
 

--- a/integration-tests/contract-v1/src/msg.rs
+++ b/integration-tests/contract-v1/src/msg.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Addr, Binary, Coin, IbcTimeout, Uint128, VoteOption};
+use cosmwasm_std::{Addr, Binary, Coin, IbcTimeout, VoteOption};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -75,7 +75,7 @@ pub enum Msg {
     Forward {
         recipient_address: Addr,
         recipient_hash: String,
-        msg: Option<Binary>,
+        msg: Binary,
     },
     FailTx {}
     //GetRandom {},
@@ -127,6 +127,7 @@ pub enum QueryMsg {
     LastIbcReceive {},
     LastIbcAck {},
     LastIbcTimeout {},
+    Forward {},
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/integration-tests/contract-v1/src/state.rs
+++ b/integration-tests/contract-v1/src/state.rs
@@ -5,6 +5,7 @@ pub const CHANNEL_KEY: &[u8] = b"channel";
 pub const ACK_KEY: &[u8] = b"ack";
 pub const RECEIVE_KEY: &[u8] = b"receive";
 pub const TIMEOUT_KEY: &[u8] = b"timeout";
+pub const FORWARD_KEY: &[u8] = b"forward";
 
 pub fn channel_store(storage: &mut dyn Storage) -> Singleton<String> {
     singleton(storage, CHANNEL_KEY)
@@ -36,4 +37,12 @@ pub fn timeout_store(storage: &mut dyn Storage) -> Singleton<String> {
 
 pub fn timeout_store_read(storage: &dyn Storage) -> ReadonlySingleton<String> {
     singleton_read(storage, TIMEOUT_KEY)
+}
+
+pub fn forward_store(storage: &mut dyn Storage) -> Singleton<String> {
+    singleton(storage, FORWARD_KEY)
+}
+
+pub fn forward_store_read(storage: &dyn Storage) -> ReadonlySingleton<String> {
+    singleton_read(storage, FORWARD_KEY)
 }

--- a/integration-tests/test.ts
+++ b/integration-tests/test.ts
@@ -134,7 +134,7 @@ beforeAll(async () => {
     };
   }
 
-  // Send 100k SCRT from account 0 to each of accounts 1-itrations
+  // Send 100k SCRT from account 0 to each of accounts 1-iterations
 
   const { secretjs } = accounts[0];
 
@@ -520,6 +520,83 @@ describe("CustomMsg", () => {
   });
 });
 
+describe.only("Rollback", () => {
+  test("v0.10", async () => {
+    const tx = await accounts[0].secretjs.tx.compute.executeContract(
+      {
+        sender: accounts[0].address,
+        contract_address: contracts["secretdev-1"].v010.address,
+        code_hash: contracts["secretdev-1"].v010.codeHash,
+        msg: {
+          forward: {
+            msg: toBase64(toUtf8(JSON.stringify({ fail_tx: {} }))),
+            recipient_address: contracts["secretdev-1"].v1.address,
+            recipient_hash: contracts["secretdev-1"].v1.codeHash,
+          }
+        },
+      },
+      { gasLimit: 250_000 }
+    );
+
+    if (tx.code !== 3) {
+      console.error(tx.rawLog);
+    }
+    expect(tx.code).toBe(3 /* WASM ErrExecuteFailed */);
+    expect(tx.rawLog).toContain("execute contract failed");
+
+    console.log("querying v10 contract state");
+    // verify the value rolled back
+    const result: any = await readonly.query.compute.queryContract({
+      contract_address: contracts["secretdev-1"].v010.address,
+      code_hash: contracts["secretdev-1"].v010.codeHash,
+      query: {
+        forward: {},
+      }
+    });
+
+    let resultString = String.fromCharCode(...result)
+    console.log("got result:", resultString);
+
+    expect(resultString).toBe("no-fail");
+  });
+
+  test("v1", async () => {
+    const tx = await accounts[0].secretjs.tx.compute.executeContract(
+      {
+        sender: accounts[0].address,
+        contract_address: contracts["secretdev-1"].v1.address,
+        code_hash: contracts["secretdev-1"].v1.codeHash,
+        msg: {
+          forward: {
+            msg: toBase64(toUtf8(JSON.stringify({ fail_tx: {} }))),
+            recipient_address: contracts["secretdev-1"].v010.address,
+            recipient_hash: contracts["secretdev-1"].v010.codeHash,
+          }
+        },
+      },
+      { gasLimit: 250_000 }
+    );
+
+    if (tx.code !== 3) {
+      console.error(tx.rawLog);
+    }
+    expect(tx.code).toBe(3 /* WASM ErrExecuteFailed */);
+    expect(tx.rawLog).toContain("execute contract failed");
+
+    console.log("querying v1 contract state");
+    // verify the value rolled back
+    const result: any = await readonly.query.compute.queryContract({
+      contract_address: contracts["secretdev-1"].v1.address,
+      code_hash: contracts["secretdev-1"].v1.codeHash,
+      query: {
+        forward: {},
+      }
+    });
+
+    expect(result).toBe("no-fail");
+  });
+});
+
 describe("tx broadcast multi", () => {
   test("Send Multiple Messages Amino", async () => {
     const { validators } = await readonly.query.staking.validators({});
@@ -896,6 +973,7 @@ describe("Wasm", () => {
 
         expect(tx.rawLog).toContain("execute contract failed");
       });
+
     });
 
     describe("v0.10", () => {
@@ -958,56 +1036,6 @@ describe("Wasm", () => {
         expect(tx.rawLog).toContain("execute contract failed");
       });
 
-      test("error in submsg + rollback", async () => {
-        const tx = await accounts[0].secretjs.tx.compute.executeContract(
-          {
-            sender: accounts[0].address,
-            contract_address: contracts["secretdev-1"].v010.address,
-            code_hash: contracts["secretdev-1"].v010.codeHash,
-            msg: {
-              wasm_msg_execute: {
-                contract_addr: contracts["secretdev-1"].v010.address,
-                callback_code_hash: contracts["secretdev-1"].v010.codeHash,
-                msg: toBase64(toUtf8(JSON.stringify({ forward: {
-                  msg: toBase64(toUtf8(JSON.stringify({ fail_tx: {} }))),
-                  recipient_address: contracts["secretdev-1"].v1.address,
-                  recipient_hash: contracts["secretdev-1"].v1.codeHash,
-                } }))),
-                send: [],
-              },
-            },
-          },
-          { gasLimit: 250_000 }
-        );
-
-        if (tx.code !== 3) {
-          console.error(tx.rawLog);
-        }
-        expect(tx.code).toBe(3 /* WASM ErrExecuteFailed */);
-        expect(tx.rawLog).toContain("execute contract failed");
-
-        // verify the value rolled back
-        const b64encode = (str: string): string =>
-          Buffer.from(str, "binary").toString("base64");
-        const result: any = await readonly.query.compute.queryContract({
-          contract_address: contracts["secretdev-1"].v1.address,
-          code_hash: contracts["secretdev-1"].v1.codeHash,
-          query: {
-            wasm_smart: {
-              contract_addr: contracts["secretdev-1"].v010.address,
-              code_hash: contracts["secretdev-1"].v010.codeHash,
-              msg: b64encode(
-                JSON.stringify({
-                  value_on_fail: {},
-                })
-              ),
-            },
-          },
-        });
-
-        // todo expect correctly
-        expect(result?.value).toBe("no-fail");
-      });
     });
   });
 });

--- a/scripts/start-node.sh
+++ b/scripts/start-node.sh
@@ -9,7 +9,7 @@ CHAINID=${3:-secretdev-1}
 rm -rf $SECRETD_HOME
 
 # Build genesis file incl account for passed address
-coins="10000000000uscrt,100000000000stake"
+coins="1000000000000000000uscrt,100000000000stake"
 $SECRETD init --chain-id $CHAINID $CHAINID --home $SECRETD_HOME
 $SECRETD keys add validator --keyring-backend="test" --home $SECRETD_HOME
 $SECRETD add-genesis-account $($SECRETD keys show validator -a --keyring-backend="test" --home $SECRETD_HOME) $coins --home $SECRETD_HOME


### PR DESCRIPTION
Adds an integration test that catches the case where a multi-message tx that fails on the last message does NOT cause the state of the contract, which changed in the initial message, to roll back.