### PR TITLE
Fix Swagger/OpenAPI Schema

### DIFF
--- a/client/docs/static/openapi/openapi.yaml
+++ b/client/docs/static/openapi/openapi.yaml
@@ -38971,7 +38971,7 @@ paths:
                         type: string
                         example: "26354"
                       tags:
-                        tyDeprecated: array
+                        type: array
                         items:
                           type: object
                           properties:
@@ -39122,7 +39122,7 @@ paths:
                               type: string
                               example: "26354"
                             tags:
-                              tyDeprecated: array
+                              type: array
                               items:
                                 type: object
                                 properties:
@@ -39232,7 +39232,7 @@ paths:
                       log:
                         type: string
                       tags:
-                        tyDeprecated: array
+                        type: array
                         items:
                           type: object
                           properties:
@@ -39266,7 +39266,7 @@ paths:
                       log:
                         type: string
                       tags:
-                        tyDeprecated: array
+                        type: array
                         items:
                           type: object
                           properties:
@@ -43277,15 +43277,13 @@ paths:
               schema:
                 type: object
                 properties:
-                  type: object
-                  properties:
-                    height:
-                      type: string
-                    result:
-                      type: object
-                      properties:
-                        ioExchPubkey:
-                          type: string
+                  height:
+                    type: string
+                  result:
+                    type: object
+                    properties:
+                      ioExchPubkey:
+                        type: string
         "404":
           description: Not Found
 components:
@@ -69089,7 +69087,7 @@ components:
         log:
           type: string
         tags:
-          tyDeprecated: array
+          type: array
           items:
             type: object
             properties:
@@ -69123,7 +69121,7 @@ components:
         log:
           type: string
         tags:
-          tyDeprecated: array
+          type: array
           items:
             type: object
             properties:
@@ -69160,7 +69158,7 @@ components:
             log:
               type: string
             tags:
-              tyDeprecated: array
+              type: array
               items:
                 type: object
                 properties:
@@ -69194,7 +69192,7 @@ components:
             log:
               type: string
             tags:
-              tyDeprecated: array
+              type: array
               items:
                 type: object
                 properties:
@@ -69313,7 +69311,7 @@ components:
               type: string
               example: "26354"
             tags:
-              tyDeprecated: array
+              type: array
               items:
                 type: object
                 properties:
@@ -69408,7 +69406,7 @@ components:
                     type: string
                     example: "26354"
                   tags:
-                    tyDeprecated: array
+                    type: array
                     items:
                       type: object
                       properties:

--- a/client/docs/static/swagger/swagger.yaml
+++ b/client/docs/static/swagger/swagger.yaml
@@ -42560,7 +42560,7 @@ paths:
                     type: string
                     example: '26354'
                   tags:
-                    tyDeprecated: array
+                    type: array
                     items:
                       type: object
                       properties:
@@ -42708,7 +42708,7 @@ paths:
                           type: string
                           example: '26354'
                         tags:
-                          tyDeprecated: array
+                          type: array
                           items:
                             type: object
                             properties:
@@ -42826,7 +42826,7 @@ paths:
                   log:
                     type: string
                   tags:
-                    tyDeprecated: array
+                    type: array
                     items:
                       type: object
                       properties:
@@ -42860,7 +42860,7 @@ paths:
                   log:
                     type: string
                   tags:
-                    tyDeprecated: array
+                    type: array
                     items:
                       type: object
                       properties:
@@ -47023,15 +47023,13 @@ paths:
           schema:
             type: object
             properties:
-              type: object
-              properties:
-                height:
-                  type: string
-                result:
-                  type: object
-                  properties:
-                    ioExchPubkey:
-                      type: string
+              height:
+                type: string
+              result:
+                type: object
+                properties:
+                  ioExchPubkey:
+                    type: string
         '404':
           description: Not Found
 definitions:
@@ -74619,7 +74617,7 @@ definitions:
       log:
         type: string
       tags:
-        tyDeprecated: array
+        type: array
         items:
           type: object
           properties:
@@ -74653,7 +74651,7 @@ definitions:
       log:
         type: string
       tags:
-        tyDeprecated: array
+        type: array
         items:
           type: object
           properties:
@@ -74690,7 +74688,7 @@ definitions:
           log:
             type: string
           tags:
-            tyDeprecated: array
+            type: array
             items:
               type: object
               properties:
@@ -74724,7 +74722,7 @@ definitions:
           log:
             type: string
           tags:
-            tyDeprecated: array
+            type: array
             items:
               type: object
               properties:
@@ -74844,7 +74842,7 @@ definitions:
             type: string
             example: '26354'
           tags:
-            tyDeprecated: array
+            type: array
             items:
               type: object
               properties:
@@ -74940,7 +74938,7 @@ definitions:
                   type: string
                   example: '26354'
                 tags:
-                  tyDeprecated: array
+                  type: array
                   items:
                     type: object
                     properties:

--- a/client/docs/swagger_legacy.yaml
+++ b/client/docs/swagger_legacy.yaml
@@ -2198,10 +2198,8 @@ paths:
         200:
           description: OK
           schema:
-            type: object
-            properties:
-              $ref: "#/definitions/IoExchPubkeyResponse"
-        "404":
+            $ref: "#/definitions/IoExchPubkeyResponse"
+        404:
           description: Not Found
 definitions:
   CodeIdContracts:
@@ -2319,7 +2317,7 @@ definitions:
       log:
         type: string
       tags:
-        tyDeprecated: array
+        type: array
         items:
           $ref: "#/definitions/KVPair"
     example:
@@ -2349,7 +2347,7 @@ definitions:
       log:
         type: string
       tags:
-        tyDeprecated: array
+        type: array
         items:
           $ref: "#/definitions/KVPair"
     example:
@@ -2426,7 +2424,7 @@ definitions:
             type: string
             example: "26354"
           tags:
-            tyDeprecated: array
+            type: array
             items:
               $ref: "#/definitions/KVPair"
   PaginatedQueryTxs:


### PR DESCRIPTION
This pull request addresses two issues in the `swagger_legacy.yaml` file:

- Corrected `tyDeprecated:` typos to `type:`
- Removed redundant object definition in the `/reg/consensus-io-exch-pubkey` endpoint response schema

Though part of the deprecated API, these errors were causing issues in the generated `openapi.yaml` and `swagger.yaml` files.

With these changes, the spec will now pass validation used by the [OpenAPI Generator tool](https://github.com/OpenAPITools/openapi-generator) when generating code.