### PR TITLE
Typo Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Click the button below to start a new development environment:
 
 1. From Docker Desktop, create a new Dev Environment from the prebuilt image - `ghcr.io/scrtlabs/secretnetwork-dev:latest`
 2. Connect with VSCode, or use the container directly
-3. Make sure the code is updated by using `get fetch` and `git pull`
+3. Make sure the code is updated by using `git fetch` and `git pull`
 
 ## Manual Set up
 


### PR DESCRIPTION
### Description

In the "Docker Dev Environments" section of the documentation, there was a typo in the Git command. The command incorrectly used `get fetch`, which is not a valid Git command. The correct command is `git fetch`.

**Changes made:**

- Replaced `get fetch` with `git fetch`.

### Importance of the fix

This typo could lead to confusion for users who are trying to follow the instructions, especially those who are not familiar with Git. Using the incorrect command (`get fetch`) would result in an error, preventing users from updating their Git repository correctly. Correcting this ensures that the instructions are clear and functional, allowing users to proceed with setting up the Docker development environment without issues.