### PR TITLE
fix: make txhash in env uppercase

### DIFF
--- a/x/compute/internal/types/types.go
+++ b/x/compute/internal/types/types.go
@@ -157,7 +157,7 @@ func NewEnv(ctx sdk.Context, creator sdk.AccAddress, deposit sdk.Coins, contract
 
 	if txCounter, ok := TXCounter(ctx); ok {
 		txhashBz := sha256.Sum256(ctx.TxBytes())
-		txhash := hex.EncodeToString(txhashBz[:])
+		txhash := strings.ToUpper(hex.EncodeToString(txhashBz[:]))
 
 		env.Transaction = &wasmTypes.TransactionInfo{
 			Index: txCounter,


### PR DESCRIPTION
Transaction hashes are represented in the event logs as uppercase hexadecimal strings. To keep this consistent so that clients can expect all transaction hashes to be in the same format, the hash provided to contracts in the `env` struct should also be uppercase.