### PR TITLE
typo-Update app.go

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -90,7 +90,7 @@ var (
 	homeDir, _     = os.UserHomeDir()
 	DefaultCLIHome = filepath.Join(homeDir, ".secretd")
 
-	// DefaultNodeHome sets the folder where the applcation data and configuration will be stored
+	// DefaultNodeHome sets the folder where the application data and configuration will be stored
 	DefaultNodeHome = filepath.Join(homeDir, ".secretd")
 
 	// Module accounts that are allowed to receive tokens


### PR DESCRIPTION
# Fix: Corrected typo in source file

## Changes
- `app/app.go:93`: "applcation" corrected to "application".

## Purpose
- Improved code accuracy and ensured professionalism by fixing the typo.
