### PR TITLE
ci: upgrade rust base image and build secret-contract-optimizer in GitHub Workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -304,6 +304,25 @@ jobs:
           name: localsecret
           path: /tmp/localsecret.tar
 
+  Build-SecretContractOptimizer:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - uses: actions/checkout@v4
+      - name: Build SecretContractOptimizer
+        uses: docker/build-push-action@v4
+        # sudo docker buildx build --platform=linux/amd64,linux/arm64/v8 -f deployment/dockerfiles/base-images/secret-contract-optimizer.Dockerfile -t enigmampc/secret-contract-optimizer:${TAG} --push .
+        with:
+          platforms: linux/amd64,linux/arm64/v8
+          file: deployment/dockerfiles/base-images/secret-contract-optimizer.Dockerfile
+          # sudo docker buildx imagetools create -t enigmampc/secret-contract-optimizer:latest enigmampc/secret-contract-optimizer:${TAG}
+          tags: |
+            ghcr.io/scrtlabs/secret-contract-optimizer:${{ github.ref_name }}
+            ghcr.io/scrtlabs/secret-contract-optimizer:latest
+          context: .
+          push: true
+
   Build-Hermes:
     runs-on: ubuntu-20.04
     steps:

--- a/Makefile
+++ b/Makefile
@@ -554,12 +554,13 @@ bin-data-develop:
 bin-data-production:
 	cd ./x/registration/internal/types && go-bindata -o ias_bin_prod.go -pkg types -prefix "../../../../ias_keys/production/" -tags "production,hw" ../../../../ias_keys/production/...
 
-# Before running this you might need to do:
-# 1. sudo docker login -u ABC -p XYZ
-# 2. sudo docker buildx create --use
-secret-contract-optimizer:
-	sudo docker buildx build --platform=linux/amd64,linux/arm64/v8 -f deployment/dockerfiles/base-images/secret-contract-optimizer.Dockerfile -t enigmampc/secret-contract-optimizer:${TAG} --push .
-	sudo docker buildx imagetools create -t enigmampc/secret-contract-optimizer:latest enigmampc/secret-contract-optimizer:${TAG}
+# Disabled the following lines in preference of building and deploying image to ghcr.io using GitHub Workflows
+# # Before running this you might need to do:
+# # 1. sudo docker login -u ABC -p XYZ
+# # 2. sudo docker buildx create --use
+# secret-contract-optimizer:
+# 	sudo docker buildx build --platform=linux/amd64,linux/arm64/v8 -f deployment/dockerfiles/base-images/secret-contract-optimizer.Dockerfile -t enigmampc/secret-contract-optimizer:${TAG} --push .
+# 	sudo docker buildx imagetools create -t enigmampc/secret-contract-optimizer:latest enigmampc/secret-contract-optimizer:${TAG}
 
 aesm-image:
 	docker build -f deployment/dockerfiles/aesm.Dockerfile -t enigmampc/aesm .

--- a/deployment/dockerfiles/base-images/secret-contract-optimizer.Dockerfile
+++ b/deployment/dockerfiles/base-images/secret-contract-optimizer.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.71.0-slim-bullseye
+FROM rust:1.83.0-slim-bullseye
 
 RUN rustup target add wasm32-unknown-unknown
 RUN apt update && apt install -y binaryen clang && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This PR upgrades the rust base image used by the secret-contract-optimizer from v1.71.0 to v1.83.0.

It also adds a job to the GitHub ci.yaml workflow to build and push this image to scrtlab's ghcr.io. Please note that I used `push: true` on the "Build SecretContractOptimizer" step but testing/modification may be required to authenticate when pushing.

EDIT: I also simply used `{{ github.ref_name }}` for the build tag, which will keep it aligned with the network version but not sure if this is desired or not.