### PR TITLE
refactor: use t.TempDir() instead of os.MkdirTemp

### DIFF
--- a/x/registration/internal/keeper/genesis_test.go
+++ b/x/registration/internal/keeper/genesis_test.go
@@ -10,9 +10,7 @@ import (
 )
 
 func TestInitGenesisNoMaster(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "wasm")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	ctx, keeper := CreateTestInput(t, false, tempDir, true)
 
 	data := types.GenesisState{
@@ -25,9 +23,7 @@ func TestInitGenesisNoMaster(t *testing.T) {
 }
 
 func TestInitGenesis(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "wasm")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	ctx, keeper := CreateTestInput(t, false, tempDir, true)
 
 	cert, err := os.ReadFile("../../testdata/attestation_cert_sw")
@@ -46,9 +42,7 @@ func TestInitGenesis(t *testing.T) {
 }
 
 func TestExportGenesis(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "wasm")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	ctx, keeper := CreateTestInput(t, false, tempDir, true)
 
 	cert, err := os.ReadFile("../../testdata/attestation_cert_sw")

--- a/x/registration/internal/keeper/keeper_test.go
+++ b/x/registration/internal/keeper/keeper_test.go
@@ -21,17 +21,13 @@ func init() {
 }
 
 func TestNewKeeper(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "reg")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	_, regKeeper := CreateTestInput(t, false, tempDir, true)
 	require.NotNil(t, regKeeper)
 }
 
 func TestNewKeeper_Node(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "reg")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	seedPath := filepath.Join(tempDir, types.SecretNodeCfgFolder, types.SecretNodeSeedNewConfig)
 
@@ -46,9 +42,7 @@ func TestNewKeeper_Node(t *testing.T) {
 }
 
 func TestKeeper_RegisterationStore(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "wasm")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	ctx, regKeeper := CreateTestInput(t, false, tempDir, true)
 
 	cert, err := os.ReadFile("../../testdata/attestation_cert_sw")
@@ -72,9 +66,7 @@ func TestKeeper_RegisterationStore(t *testing.T) {
 }
 
 func TestKeeper_RegisterNode(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "wasm")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	ctx, regKeeper := CreateTestInput(t, false, tempDir, true)
 
 	cert, err := os.ReadFile("../../testdata/attestation_cert_sw.combined")

--- a/x/registration/internal/keeper/querier_test.go
+++ b/x/registration/internal/keeper/querier_test.go
@@ -16,9 +16,7 @@ import (
 // ////
 
 func TestNewQuerier_MasterKey(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "wasm")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	ctx, keeper := CreateTestInput(t, false, tempDir, true)
 
 	querier := NewQuerier(keeper)
@@ -45,9 +43,7 @@ func TestNewQuerier_MasterKey(t *testing.T) {
 }
 
 func TestNewQuerier_MalformedNodeID(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "wasm")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	ctx, keeper := CreateTestInput(t, false, tempDir, true)
 
 	nodeIdInvalid := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -75,9 +71,7 @@ func TestNewQuerier_MalformedNodeID(t *testing.T) {
 }
 
 func TestNewQuerier_ValidNodeID(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "wasm")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	ctx, keeper := CreateTestInput(t, false, tempDir, true)
 
 	querier := NewQuerier(keeper) // TODO: Should test NewQuerier() as well


### PR DESCRIPTION
`TempDir()` is a method introduced in Go 1.15 for `testing.T`. It automatically creates a temporary directory and cleans it up after the test is complete, eliminating the hassle of manually handling errors and cleanup. 

 More detail about TempDir  https://pkg.go.dev/testing#B.TempDir