### PR TITLE
refactor: replace golang.org/x/exp with stdlib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/crypto v0.32.0
-	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
+	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	gonum.org/v1/gonum v0.15.1
 	google.golang.org/genproto v0.0.0-20240701130421-f6361c86f094 // indirect
 	google.golang.org/grpc v1.70.0

--- a/x/compute/internal/keeper/secret_contracts_exec_test.go
+++ b/x/compute/internal/keeper/secret_contracts_exec_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -19,7 +20,6 @@ import (
 	stypes "cosmossdk.io/store/types"
 
 	v010types "github.com/scrtlabs/SecretNetwork/go-cosmwasm/types/v010"
-	"golang.org/x/exp/slices"
 
 	cosmwasm "github.com/scrtlabs/SecretNetwork/go-cosmwasm/types"
 	"github.com/stretchr/testify/require"

--- a/x/compute/internal/keeper/secret_contracts_migrate_test.go
+++ b/x/compute/internal/keeper/secret_contracts_migrate_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 
@@ -17,8 +18,6 @@ import (
 
 	v010types "github.com/scrtlabs/SecretNetwork/go-cosmwasm/types/v010"
 	"github.com/scrtlabs/SecretNetwork/x/compute/internal/types"
-
-	"golang.org/x/exp/slices"
 
 	cosmwasm "github.com/scrtlabs/SecretNetwork/go-cosmwasm/types"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
Since Go 1.21, the functions in x/exp used here can already be replaced by functions from the standard library