### PR TITLE
chore: remove redundant words in comment

### DIFF
--- a/cosmwasm/enclaves/shared/cosmwasm-types/v0.10/src/types.rs
+++ b/cosmwasm/enclaves/shared/cosmwasm-types/v0.10/src/types.rs
@@ -2,7 +2,7 @@
 
 #![allow(unused)]
 
-/// These types are are copied over from the cosmwasm_std package, and must be kept in sync with it.
+/// These types are copied over from the cosmwasm_std package, and must be kept in sync with it.
 ///
 /// We copy these types instead of directly depending on them, because we require special versions of serde
 /// inside the enclave, which are different from the versions that cosmwasm_std uses.

--- a/cosmwasm/enclaves/shared/utils/src/kv_cache.rs
+++ b/cosmwasm/enclaves/shared/utils/src/kv_cache.rs
@@ -32,7 +32,7 @@ impl KvCache {
         self.readable_cache.insert(k.to_vec(), v.to_vec())
     }
     pub fn read(&self, key: &[u8]) -> Option<Vec<u8>> {
-        // first to to read from the writeable cache - this will be more updated
+        // first to read from the writeable cache - this will be more updated
         if let Some(value) = self.writeable_cache.get(key) {
             Some(value.clone())
         }

--- a/cosmwasm/packages/sgx-vm/src/instance.rs
+++ b/cosmwasm/packages/sgx-vm/src/instance.rs
@@ -104,7 +104,7 @@ where
         let api = deps.api;
         import_obj.extend(imports! {
             "env" => {
-                // Reads the database entry at the given key into the the value.
+                // Reads the database entry at the given key into the value.
                 // Returns 0 if key does not exist and pointer to result region otherwise.
                 // Ownership of the key pointer is not transferred to the host.
                 // Ownership of the value pointer is transferred to the contract.


### PR DESCRIPTION
remove redundant words in comment