### PR TITLE
ibc derivative hook migration admin

### DIFF
--- a/cosmwasm/enclaves/shared/contract-engine/src/hardcoded_admins.rs
+++ b/cosmwasm/enclaves/shared/contract-engine/src/hardcoded_admins.rs
@@ -581,6 +581,7 @@ lazy_static::lazy_static! {
         ("secret16snu3lt8k9u0xr54j2hqyhvwnx9my7kq7ay8lp", "secret1hxrvx0v0zvqgmpuzspdg5j8rrxpjgyjql3w9gh"), // ERTH
         ("secret14p6dhjznntlzw0yysl7p6z069nk0skv5e9qjut", "secret1hxrvx0v0zvqgmpuzspdg5j8rrxpjgyjql3w9gh"), // ANML
         ("secret1yrzp33hvkwd3dr5farjgwdutecrhd0r7uhqksq", "secret1ap26qrlp8mcq2pg6r47w43l0y8zkqm8a450s03"), // testnet contract
+        ("secret1r2vzslwkad9vcg06hgy4km9zh4jvawxtc2hl98", "secret16cx295surhm7ps60jsfwernx4kxa4gf8z7yxvd"),
     ]);
 
     /// The entire history of contracts that were deployed before v1.10 and have been migrated using the hardcoded admin feature.


### PR DESCRIPTION
The Shade Protocol team is requesting migration admin to be added to an ibc hooks contract used for unwrap + bridge.

https://www.mintscan.io/secret/address/secret1r2vzslwkad9vcg06hgy4km9zh4jvawxtc2hl98
