### PR TITLE
Handle short inputs in gzip and wasm detection helpers

### DIFF
--- a/x/compute/client/utils/utils.go
+++ b/x/compute/client/utils/utils.go
@@ -30,14 +30,14 @@ var (
 	wasmIdent = []byte("\x00\x61\x73\x6D")
 )
 
-// IsGzip returns checks if the file contents are gzip compressed
+// IsGzip checks if the file contents are gzip compressed
 func IsGzip(input []byte) bool {
-	return bytes.Equal(input[:3], gzipIdent)
+	return len(input) >= len(gzipIdent) && bytes.Equal(input[:len(gzipIdent)], gzipIdent)
 }
 
 // IsWasm checks if the file contents are of wasm binary
 func IsWasm(input []byte) bool {
-	return bytes.Equal(input[:4], wasmIdent)
+	return len(input) >= len(wasmIdent) && bytes.Equal(input[:len(wasmIdent)], wasmIdent)
 }
 
 // GzipIt compresses the input ([]byte)

--- a/x/compute/client/utils/utils_test.go
+++ b/x/compute/client/utils/utils_test.go
@@ -1,35 +1,29 @@
 package utils
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
-
-	"github.com/scrtlabs/SecretNetwork/x/compute/internal/keeper"
 
 	"github.com/stretchr/testify/require"
 )
 
-func GetTestData() ([]byte, []byte, []byte, error) {
-	wasmCode, err := os.ReadFile(filepath.Join("../../internal/keeper", keeper.TestContractPaths["hackatom.wasm"]))
-	if err != nil {
-		return nil, nil, nil, err
-	}
+func getTestData(t *testing.T) ([]byte, []byte, []byte) {
+	t.Helper()
 
-	gzipData, err := GzipIt(wasmCode)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
+	wasmCode := []byte{0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00}
 	someRandomStr := []byte("hello world")
+	gzipData, err := GzipIt(wasmCode)
+	require.NoError(t, err)
 
-	return wasmCode, someRandomStr, gzipData, nil
+	return wasmCode, someRandomStr, gzipData
 }
 
 func TestIsWasm(t *testing.T) {
-	wasmCode, someRandomStr, gzipData, err := GetTestData()
-	require.NoError(t, err)
+	wasmCode, someRandomStr, gzipData := getTestData(t)
 
+	t.Log("should return false for empty data")
+	require.False(t, IsWasm(nil))
+	t.Log("should return false for short data")
+	require.False(t, IsWasm([]byte{0x00, 0x61, 0x73}))
 	t.Log("should return false for some random string data")
 	require.False(t, IsWasm(someRandomStr))
 	t.Log("should return false for gzip data")
@@ -39,25 +33,24 @@ func TestIsWasm(t *testing.T) {
 }
 
 func TestIsGzip(t *testing.T) {
-	wasmCode, someRandomStr, gzipData, err := GetTestData()
-	require.NoError(t, err)
+	wasmCode, someRandomStr, gzipData := getTestData(t)
 
+	require.False(t, IsGzip(nil))
+	require.False(t, IsGzip([]byte{0x1F, 0x8B}))
 	require.False(t, IsGzip(wasmCode))
 	require.False(t, IsGzip(someRandomStr))
 	require.True(t, IsGzip(gzipData))
 }
 
 func TestGzipIt(t *testing.T) {
-	wasmCode, someRandomStr, _, err := GetTestData()
+	wasmCode, someRandomStr, _ := getTestData(t)
 	originalGzipData := []byte{
 		31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 202, 72, 205, 201, 201, 87, 40, 207, 47, 202, 73, 1,
 		4, 0, 0, 255, 255, 133, 17, 74, 13, 11, 0, 0, 0,
 	}
 
-	require.NoError(t, err)
-
 	t.Log("gzip wasm with no error")
-	_, err = GzipIt(wasmCode)
+	_, err := GzipIt(wasmCode)
 	require.NoError(t, err)
 
 	t.Log("gzip of a string should return exact gzip data")


### PR DESCRIPTION
## Summary

This PR hardens the `IsGzip` and `IsWasm` helper functions so they return `false` for empty or truncated inputs instead of panicking when slicing the input buffer.

It also updates the unit tests to cover nil/short input cases and uses a minimal wasm header fixture for these magic-byte checks.

## Why

Both helpers previously sliced the input before checking its length:

- `input[:3]` for gzip detection
- `input[:4]` for wasm detection

That can panic if callers pass empty data or a partially read file. Returning `false` is safer and matches the helpers' boolean detection behavior.

## Testing

```bash
go test -v -tags "secretcli" ./x/compute/client/utils